### PR TITLE
Add localized docs in four languages

### DIFF
--- a/docs/de/datenschutzrichtlinie.md
+++ b/docs/de/datenschutzrichtlinie.md
@@ -1,0 +1,42 @@
+# Datenschutzrichtlinie
+
+**Letzte Aktualisierung: Mai 2025**
+
+**Holidays ist eine App, die deine Privatsphäre respektiert:** *sie sammelt, speichert oder teilt keinerlei persönliche Nutzerdaten.*
+
+## Datenerfassung
+
+Die App verlangt keine unnötigen Berechtigungen und greift nicht auf sensible Daten zu.
+Alle angezeigten Informationen (nationale, touristische und religiöse Feiertage) sind öffentlich und werden lokal auf dem Gerät des Nutzers gespeichert.
+
+Die zusätzlichen Funktionen von Holidays Pro, wie Feiertagsstatistiken und Vergleiche, werden lokal auf deinem Gerät erzeugt und verarbeitet. Es werden keine Daten an externe Server gesendet oder dort gespeichert.
+
+## In-App-Käufe und kostenlose Testphase
+
+Die App bietet Abonnements über den App Store an. Alle Zahlungen, Testphasen und die Verwaltung des Abonnements erfolgen ausschließlich über Apple. **Holidays hat zu keinem Zeitpunkt Zugriff auf persönliche, finanzielle oder Abrechnungsdaten.**
+
+Wenn eine Testphase verfügbar ist, kannst du Holidays Pro während dieser Zeit kostenlos nutzen. Die Gebühren werden automatisch am Ende der Testphase berechnet, **sofern du das Abonnement nicht mindestens 24 Stunden vorher über dein App-Store-Konto kündigst.**
+
+## Optionale Berechtigungen
+
+**Benachrichtigungen:**
+Werden nur verwendet, wenn du Feiertagserinnerungen aktivierst. Dies sind lokale Benachrichtigungen auf deinem Gerät ohne Kommunikation mit externen Servern. Du kannst sie jederzeit in den Einstellungen deines Geräts deaktivieren.
+
+**Kalender:**
+Wenn du einen Feiertag in deinen Kalender einfügst, wird ein einzelnes Ereignis nach deiner Bestätigung gespeichert. Die App **kann keine anderen vorhandenen Ereignisse anzeigen, lesen oder ändern.**
+
+## Drittanbieter
+
+Holidays verwendet keine Drittanbieterdienste für Analysen, Werbung oder Datenspeicherung.
+
+## Kontakt per E-Mail
+
+Wenn du mich per E-Mail kontaktierst, teilst du deine Adresse sowie den in deinem Konto hinterlegten Namen (der auch deinen Nachnamen oder andere identifizierende Informationen enthalten kann).
+
+Diese Daten werden ausschließlich verwendet, um auf deine Anfrage zu antworten. **Sie werden niemals an Dritte weitergegeben oder verkauft.**
+
+## Kontakt
+
+Wenn du Fragen zu dieser Richtlinie hast, schreib gern im Bereich [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays ist ein Privatprojekt. Alle Anfragen werden gelesen und geschätzt.**

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,0 +1,49 @@
+[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+
+# Holidays
+
+**Holidays** ist eine iOS-App, mit der du schnell und übersichtlich alle nationalen, touristischen und religiösen Feiertage Argentiniens einsehen kannst.
+
+Ideal, um lange Wochenenden zu planen, Urlaube zu organisieren oder einfach deine Zeit besser zu nutzen.
+
+## Hauptfunktionen (kostenlos)
+
+• Countdown bis zum nächsten Feiertag
+• Vollständiger Kalender: nationale, touristische und religiöse Feiertage
+• Filter nach Typ: feste, bewegliche, touristische oder arbeitsfreie Tage
+• Suche nach Name oder Anlass des Feiertags
+• Option, vergangene Feiertage auszublenden und sich auf kommende zu konzentrieren
+• Wochenagenda, um nahe Feiertage zu sehen
+• Moderne, klare Oberfläche, die sich an alle Geräte anpasst
+
+## Erweiterte Funktionen mit Holidays Pro
+
+• Füge Feiertage deinem persönlichen Kalender hinzu
+• Richte automatische Erinnerungen ein
+• Filter nach Gemeinschaft (muslimisch, jüdisch, armenisch)
+• Detaillierte Statistiken und interaktive Diagramme
+• Monatliche Vergleiche von Feiertagen
+• Anzeige von langen Wochenenden
+• Erweiterte Suche nach Wochentag oder Monat
+• Vollständiger Kalender mit Monats- und Wochenansicht
+
+**Holidays Pro** beinhaltet eine kostenlose Testphase. Um Kosten zu vermeiden, kündige mindestens 24 Stunden vor Ablauf der Testphase.
+
+## Datenschutz und Bedingungen
+
+• [Datenschutzrichtlinie](https://lucasditomase.github.io/feriados/de/datenschutzrichtlinie)
+• [Nutzungsbedingungen](https://lucasditomase.github.io/feriados/de/nutzungsbedingungen)
+
+## Unterstützung
+
+Wenn du Fragen oder Vorschläge hast oder der Community beitreten möchtest, kannst du gerne eine [Diskussion](https://github.com/lucasditomase/feriados/discussions) starten.
+
+---
+
+*Holidays ist ein Privatprojekt. Danke, dass du unabhängige Entwickler unterstützt.*
+
+<p align="left">
+  <a href="https://apps.apple.com/app/id6744455042">
+    <img src="../images/download-badge.svg" alt="Im App Store laden" height="60">
+  </a>
+</p>

--- a/docs/de/nutzungsbedingungen.md
+++ b/docs/de/nutzungsbedingungen.md
@@ -1,0 +1,84 @@
+# Nutzungsbedingungen
+
+**Letzte Aktualisierung: Mai 2025**
+
+*Durch das Herunterladen oder Verwenden der App stimmst du diesen Bedingungen zu.*
+
+Diese Bedingungen regeln die Nutzung von **Holidays**, einer iOS-App von **Lucas Di Tomase**, die offizielle Feiertage in Argentinien anzeigt. Dir wird eine **beschränkte, nicht exklusive, nicht übertragbare und widerrufliche Lizenz** zur persönlichen Nutzung der App erteilt.
+
+## Nutzung der App
+
+Holidays ist ausschließlich für den **persönlichen, nicht kommerziellen Gebrauch** bestimmt. Sie darf nicht zum Profit, Weiterverkauf oder als Teil eines anderen Produkts oder Dienstes verwendet werden.
+
+## Inhalt
+
+Die angezeigten Informationen stammen aus öffentlichen Quellen und können sich ändern. Obwohl sie regelmäßig aktualisiert werden, **wird keine Gewähr für Genauigkeit, Vollständigkeit oder Aktualität übernommen.**
+
+## Funktionen und Abonnements
+
+Holidays bietet kostenlose Basisfunktionen, darunter:
+
+• Anzeige nationaler, touristischer und religiöser Feiertage
+• Filter nach Feiertagstyp
+• Wochenagenda bevorstehender Feiertage
+• Suche nach Name oder Anlass
+
+Erweiterte Funktionen sind über ein Abonnement namens **Holidays Pro** verfügbar und umfassen:
+
+• Gemeinschaftsspezifische Filter (muslimisch, jüdisch, armenisch)
+• Hinzufügen von Feiertagen zum persönlichen Kalender
+• Automatische Erinnerungen
+• Visuelle Statistiken und Vergleiche
+• Anzeige langer Wochenenden
+• Erweiterte Suche nach Wochentag oder Monat
+• Monats- und Wochenansichten des Kalenders
+
+## Abonnements und Testphase
+
+• Abonnements von Holidays Pro **verlängern sich automatisch**, sofern sie nicht **spätestens 24 Stunden vor** Ablauf der laufenden Periode gekündigt werden
+• Die Zahlung erfolgt über die Apple-ID, mit der der Kauf getätigt wurde
+• Wird eine **kostenlose Testphase** angeboten, beginnt das Abonnement automatisch nach deren Ende, sofern es nicht mindestens 24 Stunden vorher gekündigt wird
+• Verwaltung und Kündigung des Abonnements erfolgen in den Einstellungen deines App-Store-Kontos
+• **Preise können variieren** je nach Region, Kaufdatum und anderen von Apple oder mir als Entwickler festgelegten Bedingungen. Preise können zukünftig angepasst werden; in diesem Fall wirst du vor der automatischen Verlängerung informiert, um zu entscheiden, ob du fortfahren möchtest
+
+## Familienfreigabe
+
+Wenn du einer iCloud-Familienfreigabegruppe angehörst, kannst du dein Abonnement möglicherweise mit anderen Mitgliedern teilen, sofern diese Option in deinem App-Store-Konto aktiviert und eingerichtet ist. Diese Funktion hängt von deinem Betriebssystem und den individuellen Einstellungen ab.
+
+## Updates
+
+Die App kann ohne vorherige Ankündigung regelmäßige Updates mit Leistungsverbesserungen, Fehlerbehebungen oder neuen Funktionen erhalten.
+
+## Feedback und Vorschläge
+
+Jegliche Vorschläge, Kommentare oder Ideen können zur Verbesserung der App verwendet werden, ohne Verpflichtung zu Vergütung oder Erwähnung.
+
+## Geistiges Eigentum
+
+Sämtliche Inhalte, Oberflächen, Grafiken, Quellcodes und Funktionen von Holidays sind, sofern nicht anders angegeben, alleiniges Eigentum des Entwicklers. Durch die Nutzung der App werden keine Rechte am geistigen Eigentum eingeräumt.
+
+## Technische Einschränkungen
+
+Es ist untersagt:
+
+• Die App ohne Genehmigung zu verkaufen, zu vertreiben, zu hosten oder kommerziell zu nutzen
+• Die App zu kopieren oder anderweitig zu verwenden, außer für den persönlichen und nicht kommerziellen Gebrauch
+• Die App zu modifizieren, zu dekompilieren, Reverse Engineering durchzuführen oder zu versuchen, den Quellcode zu erlangen
+• Automatisierungen, Skripte oder andere nicht autorisierte Methoden zu verwenden, um mit der App zu interagieren
+• Ich behalte mir das Recht vor, den Zugriff auf die App ganz oder teilweise zu blockieren, wenn missbräuchliche Nutzung festgestellt wird, einschließlich belästigendem Verhalten (z. B. Spam an den Support) oder wenn das Gerät so verändert wird, dass die normale Funktionsweise der App beeinträchtigt wird (z. B. Jailbreak, nicht autorisierte Umgebungen, Nutzung von Drittanbieter-Stores oder Tools, die das In-App-Kaufsystem oder andere Funktionen verändern)
+
+Diese Liste ist nicht abschließend. Weitere Fälle können ebenfalls Einschränkungen rechtfertigen, wenn sie die Sicherheit, Integrität oder den Zweck der App gefährden.
+
+## Haftungsausschluss
+
+Die Nutzung der App erfolgt auf eigenes Risiko. **Weder der Entwickler (Lucas Di Tomase) noch die App garantieren eine ständige Verfügbarkeit oder absolute Genauigkeit der Inhalte und haften nicht für Entscheidungen, die auf Grundlage der bereitgestellten Informationen getroffen werden.**
+
+## Datenschutz
+
+Holidays erhebt keine personenbezogenen Daten und verwendet keine Dienste Dritter für Analysen oder Werbung. Weitere Informationen findest du in der [Datenschutzrichtlinie](https://lucasditomase.github.io/feriados/de/datenschutzrichtlinie).
+
+## Kontakt
+
+Bei Fragen, Unterstützung oder Vorschlägen besuche den Bereich [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays ist ein Privatprojekt. Wenn du dich meldest, lese ich deine Nachricht persönlich.**

--- a/docs/de/unterstuetzung.md
+++ b/docs/de/unterstuetzung.md
@@ -1,0 +1,57 @@
+# Unterstützung für Holidays
+
+Vielen Dank, dass du Holidays verwendest. Wenn du Fehler findest, Fragen hast oder Verbesserungen vorschlagen möchtest, kontaktiere mich gern oder beteilige dich an diesem Repository.
+Dies ist ein Privatprojekt, daher ist jedes Feedback oder jeder Beitrag sehr willkommen.
+
+## Ein Problem melden
+
+Du kannst ein Issue in diesem Repository eröffnen und das Problem sowie die Schritte zur Reproduktion beschreiben. Wenn möglich, füge einen Screenshot bei.
+
+[Issue erstellen](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20mit%20Holidays%20App&body=Beschreibe%20das%20Problem%2C%20das%20du%20festgestellt%20hast%3A%0A%0A-%20Gerät%3A%20%0A-%20iOS-Version%3A%20%0A-%20App-Version%3A%20%0A-%20Schritte%20zur%20Reproduktion%3A%0A%0A(Optional)%20Füge%20einen%20Screenshot%20oder%20eine%20Aufnahme%20hinzu%2C%20wenn%20möglich.)
+
+Du kannst mich auch per E-Mail kontaktieren, wenn du GitHub nicht verwenden möchtest. In der App gibt es unter "Weitere Infos" eine Option, eine E-Mail mit allen technischen Details zu senden (Gerätemodell, Sprache, iOS-Version usw.).
+
+## Häufig gestellte Fragen
+
+**Benötigt Holidays eine Internetverbindung?**
+Nein. Alle Daten werden lokal auf deinem Gerät gespeichert.
+
+**Kann ich Feiertage meinem Kalender hinzufügen?**
+Ja, mit Holidays Pro kannst du jeden Feiertag direkt in deinen persönlichen Kalender eintragen.
+
+**Kann ich Erinnerungen für Feiertage einstellen?**
+Ja, Holidays Pro erlaubt es, Erinnerungen einzurichten, damit du vor jedem Feiertag benachrichtigt wirst.
+
+**Was bietet die kostenlose Version?**
+Sie enthält den kompletten Kalender nationaler, touristischer und religiöser Feiertage, eine Wochenagenda und einfache Filter nach Feiertagstyp.
+
+**Welche Extras bietet Holidays Pro?**
+Es beinhaltet Erinnerungen, das Hinzufügen von Feiertagen zum Kalender, Vergleichsstatistiken, Filter nach Gemeinschaft, erweiterte Suche und verbesserte Kalenderansichten.
+
+**Warum gibt es religiöse Feiertage?**
+Holidays ermöglicht das Filtern nach Gemeinschaft (muslimisch, jüdisch, armenisch), damit jeder Nutzer relevante Daten entsprechend seinen Vorlieben sehen kann.
+
+**Sind die Feiertage immer aktuell?**
+Die Informationen stammen aus offiziellen Quellen und werden regelmäßig aktualisiert. Dennoch können unerwartete Änderungen durch Regierungsentscheidungen oder menschliche Fehler auftreten.
+
+**Sammelt die App personenbezogene Daten?**
+Nein. Holidays speichert oder überträgt keine Nutzerdaten. Alles geschieht lokal auf deinem Gerät.
+
+**Was passiert, wenn ich eine E-Mail aus der App sende?**
+Du teilst deine E-Mail-Adresse und den in deinem Konto hinterlegten Namen. Diese Informationen werden nur verwendet, um auf deine Nachricht zu antworten. **Sie werden niemals weitergegeben oder verkauft.**
+
+**Wie funktioniert Holidays Pro?**
+Es handelt sich um ein optionales Abonnement, das du über dein App-Store-Konto aktivieren oder kündigen kannst. Es umfasst erweiterte Funktionen wie Erinnerungen, Kalenderintegration, Statistiken, Gemeinschaftsfilter, erweiterte Suche, Feiertagsvergleiche und verbesserte Kalenderansichten.
+
+**Gibt es eine kostenlose Testphase?**
+Ja. Sowohl der monatliche als auch der jährliche Plan beinhalten eine kostenlose Testphase. **Wichtig:** Denke daran, *spätestens 24 Stunden vor Ende der Testphase* zu kündigen, wenn du keine Kosten möchtest.
+
+**Kann ich mein Abonnement mit meiner Familie teilen?**
+Ja, über Apple Family Sharing ohne zusätzliche Kosten, vorausgesetzt es ist in deinem App-Store-Konto korrekt eingerichtet.
+
+## Kontakt
+
+Wenn du direkt Kontakt aufnehmen oder einen öffentlichen Kommentar hinterlassen möchtest, besuche den Bereich [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Deine Nachricht geht nicht verloren.** Holidays ist ein Privatprojekt, daher lese ich alle Nachrichten und Vorschläge persönlich.
+Außerdem wird deine E-Mail-Adresse nur benutzt, um auf deine Anfrage zu antworten.

--- a/docs/fr/assistance.md
+++ b/docs/fr/assistance.md
@@ -1,0 +1,57 @@
+# Assistance pour Holidays
+
+Merci d'utiliser Holidays. Si vous trouvez des bugs, avez des questions ou souhaitez proposer des améliorations, contactez-moi ou participez à ce dépôt.
+C'est un projet personnel, tout retour ou contribution est donc très apprécié.
+
+## Signaler un problème
+
+Vous pouvez ouvrir une issue dans ce dépôt en décrivant le problème et les étapes pour le reproduire. Si possible, joignez une capture d'écran.
+
+[Ouvrir une issue](https://github.com/lucasditomase/feriados/issues/new?title=Problème%20avec%20Holidays%20App&body=Décrivez%20le%20problème%20que%20vous%20rencontrez%20ci-dessous%3A%0A%0A-%20Appareil%3A%20%0A-%20Version%20iOS%3A%20%0A-%20Version%20de%20l'application%3A%20%0A-%20Étapes%20pour%20reproduire%3A%0A%0A%28Facultatif%29%20Joignez%20une%20capture%20d'écran%20ou%20un%20enregistrement%20si%20possible.)
+
+Vous pouvez également me contacter par e-mail si vous préférez ne pas utiliser GitHub. Dans l'application, dans la section "Plus d'infos", il y a une option pour envoyer un e-mail avec tous les détails techniques inclus (modèle d'appareil, langue, version d'iOS, etc.).
+
+## Foire aux questions
+
+**Holidays nécessite-t-il une connexion internet ?**
+Non. Toutes les données sont enregistrées localement sur votre appareil.
+
+**Puis-je ajouter les fériés à mon calendrier ?**
+Oui, avec Holidays Pro vous pouvez ajouter n'importe quel férié directement à votre calendrier personnel.
+
+**Puis-je programmer des rappels pour les fériés ?**
+Oui, Holidays Pro vous permet de créer des rappels pour être notifié avant chaque férié.
+
+**Que comprend la version gratuite ?**
+Elle comprend le calendrier complet des fériés nationaux, touristiques et religieux, un agenda hebdomadaire et des filtres de base par type de férié.
+
+**Quelles fonctionnalités supplémentaires offre Holidays Pro ?**
+Elle offre des rappels, l'ajout de fériés au calendrier, des statistiques comparatives, des filtres par communauté, une recherche avancée et des vues améliorées du calendrier.
+
+**Pourquoi y a-t-il des fériés religieux ?**
+Holidays permet de filtrer par communauté (musulmane, juive, arménienne) afin que chaque utilisateur puisse voir les dates pertinentes selon ses préférences.
+
+**Les fériés sont-ils toujours à jour ?**
+Les informations proviennent de sources publiques officielles et sont mises à jour régulièrement. Cependant, des changements imprévus peuvent survenir en raison de décisions gouvernementales ou d'erreurs humaines.
+
+**L'application collecte-t-elle des données personnelles ?**
+Non. Holidays ne stocke ni ne transmet aucune donnée utilisateur. Tout se passe localement sur votre appareil.
+
+**Que se passe-t-il si j'envoie un e-mail depuis l'application ?**
+Vous partagerez votre adresse e-mail et le nom configuré dans votre compte. Ces informations sont utilisées uniquement pour répondre à votre message. **Elles ne sont jamais partagées ni vendues.**
+
+**Comment fonctionne Holidays Pro ?**
+Il s'agit d'un abonnement facultatif que vous pouvez activer ou annuler depuis votre compte App Store. Il inclut des fonctionnalités avancées telles que des rappels, l'intégration au calendrier, des statistiques, des filtres par communauté, une recherche avancée, la comparaison des fériés et des vues du calendrier améliorées.
+
+**Y a-t-il une période d'essai gratuite ?**
+Oui. Les plans mensuel et annuel comprennent une période d'essai gratuite. **Important :** pensez à annuler *au moins 24 heures avant la fin de l'essai* si vous ne voulez pas être facturé.
+
+**Puis-je partager mon abonnement avec ma famille ?**
+Oui, via le partage familial Apple, sans frais supplémentaires, à condition qu'il soit correctement configuré dans votre compte App Store.
+
+## Contact
+
+Si vous souhaitez me contacter directement ou laisser un commentaire public, rejoignez la section [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Votre message ne sera pas perdu.** Holidays est un projet personnel, je lis donc personnellement tous les messages et suggestions.
+De plus, votre adresse e-mail n'est utilisée que pour répondre à votre demande.

--- a/docs/fr/conditions-generales.md
+++ b/docs/fr/conditions-generales.md
@@ -1,0 +1,84 @@
+# Conditions générales d'utilisation
+
+**Dernière mise à jour : mai 2025**
+
+*En téléchargeant ou en utilisant l'application, vous acceptez ces conditions.*
+
+Ces conditions régissent l'utilisation de **Holidays**, une application iOS développée par **Lucas Di Tomase** pour afficher les jours fériés officiels d'Argentine. Vous disposez d'une **licence limitée, non exclusive, non transmissible et révocable** pour utiliser l'application à des fins personnelles.
+
+## Utilisation de l'application
+
+Holidays est destinée à un **usage personnel et non commercial** uniquement. Elle ne peut pas être utilisée à des fins lucratives, revendue ou intégrée à un autre produit ou service.
+
+## Contenu
+
+Les informations affichées dans l'application proviennent de sources publiques et peuvent être modifiées. Bien qu'elles soient régulièrement mises à jour, **l'exactitude, l'exhaustivité ou l'actualité des informations n'est pas garantie.**
+
+## Fonctionnalités et abonnements
+
+Holidays offre gratuitement des fonctionnalités de base, notamment :
+
+• Affichage des jours fériés nationaux, touristiques et religieux
+• Filtres par type de férié
+• Agenda hebdomadaire des fériés à venir
+• Recherche par nom ou motif
+
+Des fonctionnalités avancées sont disponibles via un abonnement appelé **Holidays Pro**, qui inclut :
+
+• Filtres par communauté spécifique (musulmane, juive, arménienne)
+• Ajout des fériés à votre calendrier personnel
+• Rappels automatiques
+• Statistiques visuelles et comparaisons
+• Visualisation des ponts
+• Recherche avancée par jour de la semaine ou mois
+• Vues mensuelles et hebdomadaires du calendrier
+
+## Abonnements et période d'essai
+
+• Les abonnements à Holidays Pro **se renouvellent automatiquement** sauf annulation **au moins 24 heures avant** la fin de la période en cours
+• Le paiement est effectué via l'identifiant Apple utilisé pour l'achat
+• Si une **période d'essai gratuite** est proposée, l'abonnement commencera automatiquement à la fin de celle-ci sauf annulation au moins 24 heures à l'avance
+• La gestion et l'annulation de l'abonnement doivent être effectuées dans les réglages de votre compte App Store
+• **Les prix peuvent varier** selon la région, la date d'achat et d'autres conditions définies par Apple ou par moi en tant que développeur. Les prix peuvent être mis à jour à l'avenir ; dans ce cas vous serez informé avant le renouvellement automatique pour décider de continuer ou non
+
+## Partage familial
+
+Si vous faites partie d'un groupe de partage familial iCloud, vous pourrez peut-être partager votre abonnement avec d'autres membres, à condition que cette option soit activée et configurée dans votre compte App Store. Cette fonctionnalité dépend de votre système d'exploitation et des paramètres individuels.
+
+## Mises à jour
+
+L'application peut recevoir des mises à jour périodiques apportant des améliorations, des corrections de bugs ou de nouvelles fonctionnalités sans préavis.
+
+## Commentaires et suggestions
+
+Toute suggestion, tout commentaire ou idée que vous soumettez pourra être utilisé pour améliorer l'application, sans obligation de compensation ni d'attribution.
+
+## Propriété intellectuelle
+
+Tout le contenu, les interfaces, les graphismes, le code source et les fonctionnalités de Holidays sont la propriété exclusive du développeur, sauf indication contraire. Aucun droit de propriété intellectuelle n'est accordé à l'utilisateur par l'usage de l'application.
+
+## Restrictions techniques
+
+Il est interdit :
+
+• De vendre, distribuer, héberger ou exploiter commercialement l'application sans autorisation
+• De copier ou d'utiliser l'application à toute fin autre que l'usage personnel et non commercial
+• De modifier, décompiler, faire de l'ingénierie inverse ou tenter d'accéder au code source
+• D'utiliser des automatisations, scripts ou autres méthodes non autorisées pour interagir avec l'application
+• Je me réserve le droit de bloquer l'accès à l'application, en tout ou en partie, en cas d'utilisation abusive, y compris un comportement agressif (par exemple l'envoi massif de courriels au support technique) ou si l'appareil est modifié de manière à affecter le fonctionnement normal de l'application (appareils jailbreakés, environnements non autorisés, utilisation de stores tiers ou d'outils modifiant les achats intégrés ou toute autre fonctionnalité)
+
+Cette liste n'est pas exhaustive. D'autres cas peuvent également justifier des restrictions s'ils compromettent la sécurité, l'intégrité ou l'objectif de l'application.
+
+## Clause de non-responsabilité
+
+L'utilisation de l'application se fait à vos risques et périls. **Ni le développeur (Lucas Di Tomase) ni l'application ne garantissent une disponibilité continue ou une exactitude absolue du contenu et ne sauraient être tenus responsables des décisions prises sur la base des informations fournies.**
+
+## Confidentialité
+
+Holidays ne collecte pas de données personnelles et n'utilise pas de services tiers pour l'analyse ou la publicité. Pour plus de détails, veuillez consulter la [Politique de confidentialité](https://lucasditomase.github.io/feriados/fr/politique-de-confidentialite).
+
+## Contact
+
+Pour toute question, assistance ou suggestion, rendez-vous dans la section [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays est un projet personnel. Si vous me contactez, je lirai personnellement votre message.**

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,0 +1,49 @@
+[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+
+# Holidays
+
+**Holidays** est une application iOS qui vous permet de consulter rapidement et clairement tous les jours fériés nationaux, touristiques et religieux d'Argentine.
+
+Parfaite pour planifier les week-ends prolongés, organiser des vacances ou simplement mieux gérer votre temps.
+
+## Fonctionnalités principales (gratuites)
+
+• Compte à rebours jusqu'au prochain jour férié
+• Calendrier complet : fériés nationaux, touristiques et religieux
+• Filtres par type : fixes, mobiles, touristiques ou jours non travaillés
+• Recherche par nom ou motif du férié
+• Option pour masquer les fériés passés et se concentrer sur les prochains
+• Agenda hebdomadaire pour voir les fériés proches
+• Interface moderne et claire adaptée à tous les appareils
+
+## Fonctionnalités avancées avec Holidays Pro
+
+• Ajoutez les fériés à votre calendrier personnel
+• Programmez des rappels automatiques
+• Filtres par communauté (musulmane, juive, arménienne)
+• Statistiques détaillées et graphiques interactifs
+• Comparaisons mensuelles des fériés
+• Visualisation des ponts
+• Recherche avancée par jour de la semaine ou par mois
+• Calendrier complet avec vues mensuelle et hebdomadaire
+
+**Holidays Pro** comprend une période d'essai gratuite. Pour éviter les frais, veillez à annuler au moins 24 heures avant la fin de l'essai.
+
+## Politique de confidentialité et conditions
+
+• [Politique de confidentialité](https://lucasditomase.github.io/feriados/fr/politique-de-confidentialite)
+• [Conditions générales](https://lucasditomase.github.io/feriados/fr/conditions-generales)
+
+## Assistance
+
+Si vous avez des questions, des suggestions ou souhaitez rejoindre la communauté, n'hésitez pas à ouvrir une [discussion](https://github.com/lucasditomase/feriados/discussions).
+
+---
+
+*Holidays est un projet personnel. Merci de soutenir les développeurs indépendants.*
+
+<p align="left">
+  <a href="https://apps.apple.com/app/id6744455042">
+    <img src="../images/download-badge.svg" alt="Télécharger sur l'App Store" height="60">
+  </a>
+</p>

--- a/docs/fr/politique-de-confidentialite.md
+++ b/docs/fr/politique-de-confidentialite.md
@@ -1,0 +1,42 @@
+# Politique de confidentialité
+
+**Dernière mise à jour : mai 2025**
+
+**Holidays est une application qui respecte votre vie privée :** *elle ne collecte, ne stocke ni ne partage aucune information personnelle des utilisateurs.*
+
+## Collecte de données
+
+L'application ne demande pas d'autorisations inutiles et n'accède pas à des données sensibles.
+Toutes les informations affichées (fériés nationaux, touristiques et religieux) sont publiques et stockées localement sur l'appareil de l'utilisateur.
+
+Les fonctionnalités supplémentaires de Holidays Pro, telles que les statistiques et comparaisons de fériés, sont générées et traitées localement sur votre appareil. Aucune information n'est envoyée ou stockée sur des serveurs externes.
+
+## Achats intégrés et période d'essai gratuite
+
+L'application propose des abonnements via l'App Store. Tout le traitement des paiements, les périodes d'essai et la gestion des abonnements sont assurés exclusivement par Apple. **Holidays n'accède jamais à vos informations personnelles, financières ou de facturation.**
+
+S'il existe une période d'essai, vous pourrez utiliser Holidays Pro sans frais pendant cette durée. Vous serez facturé automatiquement à la fin de l'essai, **sauf si vous annulez l'abonnement au moins 24 heures à l'avance** depuis votre compte App Store.
+
+## Permissions optionnelles
+
+**Notifications :**
+Utilisées uniquement si vous activez les rappels de fériés. Ce sont des notifications locales générées sur votre appareil, sans communication avec des serveurs externes. Vous pouvez les désactiver à tout moment dans les réglages de votre appareil.
+
+**Calendrier :**
+Si vous choisissez d'ajouter un férié à votre calendrier, un seul événement est enregistré après votre confirmation. L'application **ne peut pas voir, lire ou modifier d'autres événements** existants.
+
+## Tiers
+
+Holidays n'utilise aucun service tiers pour l'analyse, la publicité ou le stockage de données.
+
+## Contact par e-mail
+
+Si vous choisissez de me contacter par e-mail, vous partagerez votre adresse ainsi que le nom configuré dans votre compte (qui peut inclure votre nom de famille ou d'autres informations d'identification).
+
+Ces informations servent uniquement à répondre à votre demande. **Elles ne sont jamais partagées ni vendues à des tiers.**
+
+## Contact
+
+Si vous avez des questions sur cette politique, n'hésitez pas à consulter la section [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays est un projet personnel. Tous les messages sont lus et appréciés.**

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -1,0 +1,49 @@
+[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+
+# Holidays
+
+**Holidays** è un'app per iOS che ti permette di consultare in modo rapido e chiaro tutte le festività nazionali, turistiche e religiose dell'Argentina.
+
+Perfetta per pianificare i ponti, organizzare le vacanze o semplicemente sfruttare meglio il tuo tempo.
+
+## Funzioni principali (gratuite)
+
+• Conto alla rovescia per la prossima festività
+• Calendario completo: festività nazionali, turistiche e religiose
+• Filtri per tipo: fisse, mobili, turistiche o non lavorative
+• Ricerca per nome o motivo della festività
+• Opzione per nascondere le festività passate e concentrarti su quelle future
+• Agenda settimanale per vedere le festività vicine
+• Interfaccia moderna e chiara adattabile a tutti i dispositivi
+
+## Funzionalità avanzate con Holidays Pro
+
+• Aggiungi le festività al tuo calendario personale
+• Imposta promemoria automatici
+• Filtri per comunità (musulmana, ebraica, armena)
+• Statistiche dettagliate e grafici interattivi
+• Confronti mensili delle festività
+• Visualizzazione dei ponti
+• Ricerca avanzata per giorno della settimana o mese
+• Calendario completo con viste mensile e settimanale
+
+**Holidays Pro** include una prova gratuita. Per evitare l'addebito, assicurati di annullarla almeno 24 ore prima della scadenza.
+
+## Informativa sulla privacy e termini
+
+• [Informativa sulla privacy](https://lucasditomase.github.io/feriados/it/informativa-sulla-privacy)
+• [Termini e condizioni](https://lucasditomase.github.io/feriados/it/termini-e-condizioni)
+
+## Supporto
+
+Se hai domande, suggerimenti o vuoi partecipare alla community, sentiti libero di aprire una [discussione](https://github.com/lucasditomase/feriados/discussions).
+
+---
+
+*Holidays è un progetto personale. Grazie per sostenere gli sviluppatori indipendenti.*
+
+<p align="left">
+  <a href="https://apps.apple.com/app/id6744455042">
+    <img src="../images/download-badge.svg" alt="Scarica sull'App Store" height="60">
+  </a>
+</p>

--- a/docs/it/informativa-sulla-privacy.md
+++ b/docs/it/informativa-sulla-privacy.md
@@ -1,0 +1,42 @@
+# Informativa sulla privacy
+
+**Ultimo aggiornamento: maggio 2025**
+
+**Holidays è un'app che rispetta la tua privacy:** *non raccoglie, conserva né condivide informazioni personali degli utenti.*
+
+## Raccolta dei dati
+
+L'app non richiede permessi non necessari né accede a dati sensibili.
+Tutte le informazioni mostrate (festività nazionali, turistiche e religiose) sono pubbliche e memorizzate localmente sul dispositivo dell'utente.
+
+Le funzioni aggiuntive di Holidays Pro, come le statistiche e i confronti delle festività, vengono generate e processate localmente sul tuo dispositivo. Nessuna informazione viene inviata o salvata su server esterni.
+
+## Acquisti in-app e prova gratuita
+
+L'app offre abbonamenti tramite l'App Store. Tutti i pagamenti, le prove gratuite e la gestione degli abbonamenti sono gestiti esclusivamente da Apple. **Holidays non accede in alcun momento a dati personali, finanziari o di fatturazione.**
+
+Se è disponibile un periodo di prova, potrai utilizzare Holidays Pro gratuitamente durante tale periodo. Verrai addebitato automaticamente alla fine della prova **a meno che tu non annulli l'abbonamento almeno 24 ore prima** tramite il tuo account App Store.
+
+## Permessi facoltativi
+
+**Notifiche:**
+Utilizzate solo se abiliti i promemoria delle festività. Si tratta di notifiche locali generate sul dispositivo, senza comunicazione con server esterni. Puoi disattivarle in qualsiasi momento dalle impostazioni del dispositivo.
+
+**Calendario:**
+Se decidi di aggiungere una festività al tuo calendario, verrà salvato un singolo evento con la tua conferma. L'app **non può visualizzare, leggere o modificare altri eventi esistenti.**
+
+## Terze parti
+
+Holidays non utilizza servizi di terze parti per analisi, pubblicità o archiviazione dei dati.
+
+## Contatto email
+
+Se scegli di contattarmi via email, condividerai il tuo indirizzo e il nome configurato nel tuo account (che potrebbe includere il cognome o altre informazioni identificative).
+
+Queste informazioni vengono usate esclusivamente per rispondere alla tua richiesta. **Non vengono mai condivise con terzi né vendute in nessun caso.**
+
+## Contatto
+
+Se hai domande su questa politica, sentiti libero di scrivere nella sezione [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays è un progetto personale. Tutte le richieste vengono lette e apprezzate.**

--- a/docs/it/supporto.md
+++ b/docs/it/supporto.md
@@ -1,0 +1,57 @@
+# Supporto per Holidays
+
+Grazie per utilizzare Holidays. Se trovi bug, hai domande o vuoi suggerire miglioramenti, contattami pure o partecipa a questo repository.
+Si tratta di un progetto personale, quindi ogni feedback o contributo è molto apprezzato.
+
+## Segnala un problema
+
+Puoi aprire un'issue in questo repository descrivendo il problema e i passaggi per riprodurlo. Se possibile, allega uno screenshot.
+
+[Apri un'issue](https://github.com/lucasditomase/feriados/issues/new?title=Problema%20con%20Holidays%20App&body=Descrivi%20il%20problema%20che%20stai%20riscontrando%20qui%3A%0A%0A-%20Dispositivo%3A%20%0A-%20Versione%20iOS%3A%20%0A-%20Versione%20app%3A%20%0A-%20Passaggi%20per%20riprodurre%3A%0A%0A(Opzionale)%20Allega%20uno%20screenshot%20o%20una%20registrazione%20se%20puoi.)
+
+Puoi anche contattarmi via email se preferisci non usare GitHub. Nell'app, nella sezione "Maggiori informazioni", c'è un'opzione per inviare una email con tutti i dettagli tecnici inclusi (modello del dispositivo, lingua, versione di iOS, ecc.).
+
+## Domande frequenti
+
+**Holidays richiede una connessione internet?**
+No. Tutti i dati sono salvati localmente sul dispositivo.
+
+**Posso aggiungere le festività al calendario?**
+Sì, con Holidays Pro puoi aggiungere qualsiasi festività direttamente al tuo calendario personale.
+
+**Posso impostare promemoria per le festività?**
+Sì, Holidays Pro ti permette di creare promemoria per essere avvisato prima di ogni festività.
+
+**Cosa include la versione gratuita?**
+Include il calendario completo di festività nazionali, turistiche e religiose, un'agenda settimanale e filtri base per tipo di festività.
+
+**Quali funzioni extra offre Holidays Pro?**
+Include promemoria, aggiunta delle festività al calendario, statistiche comparative, filtri per comunità, ricerca avanzata e viste del calendario migliorate.
+
+**Perché ci sono festività religiose?**
+Holidays permette di filtrare per comunità (musulmana, ebraica, armena) così ogni utente può visualizzare le date rilevanti in base alle proprie preferenze.
+
+**Le festività sono sempre aggiornate?**
+Le informazioni provengono da fonti pubbliche ufficiali e vengono aggiornate regolarmente. Tuttavia potrebbero esserci variazioni impreviste dovute a decisioni governative o errori umani.
+
+**L'app raccoglie dati personali?**
+No. Holidays non memorizza né trasmette dati degli utenti. Tutto avviene localmente sul dispositivo.
+
+**Cosa succede se invio un'email dall'app?**
+Condividerai il tuo indirizzo email e il nome configurato nel tuo account. Queste informazioni vengono usate solo per rispondere al tuo messaggio. **Non vengono mai condivise o vendute.**
+
+**Come funziona Holidays Pro?**
+È un abbonamento opzionale che puoi attivare o cancellare dal tuo account App Store. Include funzionalità avanzate come promemoria, integrazione con il calendario, statistiche, filtri per comunità, ricerca avanzata, confronti tra festività e viste del calendario migliorate.
+
+**Esiste una prova gratuita?**
+Sì. Sia il piano mensile che quello annuale includono una prova gratuita. **Importante:** ricorda di annullare *almeno 24 ore prima che termini* se non vuoi che ti venga addebitato nulla.
+
+**Posso condividere l'abbonamento con la mia famiglia?**
+Sì, tramite Condivisione familiare di Apple, senza costi aggiuntivi, a patto che sia configurato correttamente nel tuo account App Store.
+
+## Contatto
+
+Se vuoi metterti in contatto direttamente o lasciare un commento pubblico, puoi partecipare alla sezione [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Il tuo messaggio non andrà perso.** Holidays è un progetto personale, quindi leggo personalmente tutti i messaggi e i suggerimenti.
+Inoltre, il tuo indirizzo email viene usato solo per rispondere alla tua richiesta.

--- a/docs/it/termini-e-condizioni.md
+++ b/docs/it/termini-e-condizioni.md
@@ -1,0 +1,84 @@
+# Termini e condizioni d'uso
+
+**Ultimo aggiornamento: maggio 2025**
+
+*Scaricando o utilizzando l'app accetti questi termini.*
+
+Questi termini regolano l'uso di **Holidays**, un'applicazione iOS sviluppata da **Lucas Di Tomase** per mostrare i giorni festivi ufficiali in Argentina. Ti viene concessa una **licenza limitata, non esclusiva, non trasferibile e revocabile** per utilizzare l'app a fini personali.
+
+## Uso dell'app
+
+Holidays è destinata esclusivamente a un **uso personale e non commerciale**. Non può essere utilizzata a scopo di lucro, rivenduta o incorporata in altri prodotti o servizi.
+
+## Contenuto
+
+Le informazioni visualizzate nell'app provengono da fonti pubbliche e possono subire variazioni. Pur essendo aggiornate regolarmente, **non si garantisce l'esattezza, la completezza o la tempestività delle informazioni.**
+
+## Funzioni e abbonamenti
+
+Holidays offre gratuitamente funzioni di base, tra cui:
+
+• Visualizzazione dei giorni festivi nazionali, turistici e religiosi
+• Filtri per tipo di festività
+• Agenda settimanale delle festività imminenti
+• Ricerca per nome o motivo
+
+Funzioni avanzate sono disponibili tramite un abbonamento chiamato **Holidays Pro**, che include:
+
+• Filtri per comunità specifiche (musulmana, ebraica, armena)
+• Aggiunta dei festivi al tuo calendario personale
+• Promemoria automatici
+• Statistiche e confronti visivi
+• Visualizzazione dei ponti
+• Ricerca avanzata per giorno della settimana o mese
+• Viste mensili e settimanali del calendario
+
+## Abbonamenti e prova gratuita
+
+• Gli abbonamenti a Holidays Pro **si rinnovano automaticamente** a meno che non vengano cancellati **almeno 24 ore prima** della fine del periodo in corso
+• Il pagamento viene addebitato sull'ID Apple utilizzato per l'acquisto
+• Se è prevista una **prova gratuita**, l'abbonamento inizierà automaticamente al termine della prova a meno che non venga cancellato con almeno 24 ore di anticipo
+• La gestione e la cancellazione dell'abbonamento devono essere effettuate dalle impostazioni del tuo account App Store
+• **I prezzi possono variare** in base alla regione, alla data di acquisto e ad altre condizioni stabilite da Apple o da me come sviluppatore. I prezzi potranno essere aggiornati in futuro; in tal caso sarai avvisato prima del rinnovo automatico per decidere se continuare
+
+## Condivisione in famiglia
+
+Se fai parte di un gruppo "In famiglia" di iCloud, potresti condividere l'abbonamento con altri membri, a patto che l'opzione sia abilitata e configurata nel tuo account App Store. Questa funzione dipende dal sistema operativo e dalle impostazioni individuali.
+
+## Aggiornamenti
+
+L'app può ricevere aggiornamenti periodici con miglioramenti, correzioni di bug o nuove funzionalità senza preavviso.
+
+## Feedback e suggerimenti
+
+Qualsiasi suggerimento, commento o idea inviati potranno essere utilizzati per migliorare l'app, senza obbligo di compenso o attribuzione.
+
+## Proprietà intellettuale
+
+Tutti i contenuti, le interfacce, la grafica, il codice sorgente e le funzionalità di Holidays sono di esclusiva proprietà dello sviluppatore, salvo diversa indicazione. Nessun diritto di proprietà intellettuale viene concesso all'utente attraverso l'uso dell'app.
+
+## Restrizioni tecniche
+
+È vietato:
+
+• Vendere, distribuire, ospitare o sfruttare commercialmente l'app senza autorizzazione
+• Copiare o utilizzare l'app per scopi diversi dall'uso personale e non commerciale
+• Modificare, decompilare, fare reverse engineering o tentare di accedere al codice sorgente
+• Utilizzare automazioni, script o altri metodi non autorizzati per interagire con l'app
+• Mi riservo il diritto di bloccare l'accesso all'app, in tutto o in parte, se viene rilevato un uso improprio, compresi comportamenti abusivi (come lo spam al supporto tecnico) o se il dispositivo viene modificato in modo da compromettere il normale funzionamento dell'app (ad esempio dispositivi jailbroken, ambienti non autorizzati, utilizzo di store di terze parti o strumenti che alterano il sistema di acquisti in-app o altre funzioni)
+
+Questo elenco non è esaustivo. Altri casi potrebbero giustificare restrizioni se compromettono la sicurezza, l'integrità o lo scopo dell'app.
+
+## Esclusione di responsabilità
+
+L'uso dell'app avviene a tuo rischio. **Né lo sviluppatore (Lucas Di Tomase) né l'app garantiscono disponibilità continua o assoluta accuratezza dei contenuti e non sono responsabili per decisioni prese sulla base delle informazioni fornite.**
+
+## Privacy
+
+Holidays non raccoglie dati personali né utilizza servizi di terze parti per analisi o pubblicità. Per maggiori dettagli consulta l'[Informativa sulla privacy](https://lucasditomase.github.io/feriados/it/informativa-sulla-privacy).
+
+## Contatto
+
+Per domande, supporto o suggerimenti puoi visitare la sezione [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays è un progetto personale. Se ci contatti, leggerò personalmente il tuo messaggio.**

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,0 +1,49 @@
+[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+
+# Holidays
+
+**Holidays** é um aplicativo para iOS que permite consultar de forma rápida e clara todos os feriados nacionais, turísticos e religiosos da Argentina.
+
+Perfeito para planejar feriados prolongados, organizar férias ou simplesmente aproveitar melhor seu tempo.
+
+## Principais recursos (grátis)
+
+• Contagem regressiva para o próximo feriado
+• Calendário completo: feriados nacionais, turísticos e religiosos
+• Filtros por tipo: fixos, móveis, turísticos ou não laborais
+• Busca por nome ou motivo do feriado
+• Opção para ocultar feriados passados e focar nos próximos
+• Agenda semanal para ver os feriados próximos
+• Interface moderna e clara adaptável a todos os dispositivos
+
+## Recursos avançados com Holidays Pro
+
+• Adicione feriados ao seu calendário pessoal
+• Defina lembretes automáticos
+• Filtros por comunidade (muçulmana, judaica, armênia)
+• Estatísticas detalhadas e gráficos interativos
+• Comparativos mensais de feriados
+• Visualização de feriados prolongados
+• Busca avançada por dia da semana ou mês
+• Calendário completo com vistas mensal e semanal
+
+**Holidays Pro** inclui um período de teste gratuito. Para evitar cobranças, cancele pelo menos 24 horas antes do fim do período.
+
+## Política de privacidade e termos
+
+• [Política de privacidade](https://lucasditomase.github.io/feriados/pt/politica-de-privacidade)
+• [Termos e condições](https://lucasditomase.github.io/feriados/pt/termos-e-condicoes)
+
+## Suporte
+
+Se você tiver dúvidas, sugestões ou quiser participar da comunidade, fique à vontade para abrir uma [discussão](https://github.com/lucasditomase/feriados/discussions).
+
+---
+
+*Holidays é um projeto pessoal. Obrigado por apoiar desenvolvedores independentes.*
+
+<p align="left">
+  <a href="https://apps.apple.com/app/id6744455042">
+    <img src="../images/download-badge.svg" alt="Baixar na App Store" height="60">
+  </a>
+</p>

--- a/docs/pt/politica-de-privacidade.md
+++ b/docs/pt/politica-de-privacidade.md
@@ -1,0 +1,42 @@
+# Política de privacidade
+
+**Atualização mais recente: maio de 2025**
+
+**Holidays é um aplicativo que respeita sua privacidade:** *não coleta, armazena nem compartilha informações pessoais dos usuários.*
+
+## Coleta de dados
+
+O aplicativo não solicita permissões desnecessárias nem acessa dados sensíveis.
+Todas as informações exibidas (feriados nacionais, turísticos e religiosos) são públicas e armazenadas localmente no dispositivo do usuário.
+
+Os recursos adicionais do Holidays Pro, como estatísticas e comparações de feriados, são gerados e processados localmente no seu dispositivo. Nenhuma informação é enviada ou armazenada em servidores externos.
+
+## Compras dentro do app e período de teste gratuito
+
+O aplicativo oferece assinaturas pela App Store. Todo o processamento de pagamento, testes gratuitos e gestão da assinatura são feitos exclusivamente pela Apple. **Holidays não acessa dados pessoais, financeiros ou de faturamento em nenhum momento.**
+
+Se houver um período de teste disponível, você poderá usar o Holidays Pro gratuitamente durante esse tempo. A cobrança será feita automaticamente ao final do período, **a menos que você cancele a assinatura com pelo menos 24 horas de antecedência** na sua conta da App Store.
+
+## Permissões opcionais
+
+**Notificações:**
+Usadas apenas se você ativar os lembretes de feriados. São notificações locais geradas no aparelho, sem comunicação com servidores externos. Você pode desativá-las a qualquer momento nas configurações do dispositivo.
+
+**Calendário:**
+Se você decidir adicionar um feriado ao seu calendário, será salvo um único evento mediante confirmação. O app **não pode visualizar, ler ou modificar outros eventos** existentes.
+
+## Terceiros
+
+Holidays não utiliza serviços de terceiros para análise, publicidade ou armazenamento de dados.
+
+## Contato por email
+
+Caso decida entrar em contato por email, você compartilhará seu endereço e o nome configurado em sua conta (que pode incluir sobrenome ou outras informações identificadoras).
+
+Essas informações são usadas apenas para responder à sua solicitação. **Nunca são compartilhadas com terceiros nem vendidas sob nenhuma circunstância.**
+
+## Contato
+
+Se tiver dúvidas sobre esta política, sinta-se à vontade para escrever na seção [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays é um projeto pessoal. Todas as mensagens são lidas e valorizadas.**

--- a/docs/pt/suporte.md
+++ b/docs/pt/suporte.md
@@ -1,0 +1,57 @@
+# Suporte ao Holidays
+
+Obrigado por usar o Holidays. Se encontrar bugs, tiver dúvidas ou quiser sugerir melhorias, entre em contato comigo ou participe deste repositório.
+Este é um projeto pessoal, portanto qualquer feedback ou contribuição é muito bem-vindo.
+
+## Relatar um problema
+
+Você pode abrir uma issue neste repositório descrevendo o problema e os passos para reproduzi-lo. Se possível, inclua uma captura de tela.
+
+[Abrir uma issue](https://github.com/lucasditomase/feriados/issues/new?title=Problema%20com%20Holidays%20App&body=Descreva%20o%20problema%20que%20você%20está%20enfrentando%20abaixo%3A%0A%0A-%20Dispositivo%3A%20%0A-%20Versão%20do%20iOS%3A%20%0A-%20Versão%20do%20app%3A%20%0A-%20Passos%20para%20reproduzir%3A%0A%0A(Opcional)%20Anexe%20uma%20captura%20de%20tela%20ou%20gravação%20se%20puder.)
+
+Você também pode me contatar por email se preferir não usar o GitHub. No app, na seção "Mais informações", há uma opção para enviar um email com todos os detalhes técnicos já incluídos (modelo do dispositivo, idioma, versão do iOS, etc.).
+
+## Perguntas frequentes
+
+**O Holidays precisa de conexão com a internet?**
+Não. Todos os dados ficam armazenados localmente no dispositivo.
+
+**Posso adicionar os feriados ao meu calendário?**
+Sim, com o Holidays Pro você pode adicionar qualquer feriado diretamente ao seu calendário pessoal.
+
+**Posso configurar lembretes para os feriados?**
+Sim, o Holidays Pro permite criar lembretes para ser notificado antes de cada feriado.
+
+**O que inclui a versão gratuita?**
+Inclui o calendário completo de feriados nacionais, turísticos e religiosos, uma agenda semanal e filtros básicos por tipo de feriado.
+
+**Quais recursos extras o Holidays Pro oferece?**
+Inclui lembretes, adição de feriados ao calendário, estatísticas comparativas, filtros por comunidade, busca avançada e visualizações aprimoradas do calendário.
+
+**Por que existem feriados religiosos?**
+O Holidays permite filtrar por comunidade (muçulmana, judaica, armênia) para que cada usuário veja as datas relevantes de acordo com suas preferências.
+
+**Os feriados estão sempre atualizados?**
+As informações provêm de fontes públicas oficiais e são atualizadas regularmente. Entretanto, podem ocorrer mudanças inesperadas devido a decisões do governo ou erro humano.
+
+**O aplicativo coleta dados pessoais?**
+Não. O Holidays não armazena nem transmite dados dos usuários. Tudo acontece localmente no dispositivo.
+
+**O que acontece se eu enviar um email pelo app?**
+Você compartilhará seu endereço de email e o nome configurado na sua conta. Essas informações são usadas apenas para responder à sua mensagem. **Nunca são compartilhadas ou vendidas.**
+
+**Como funciona o Holidays Pro?**
+É uma assinatura opcional que você pode ativar ou cancelar na sua conta da App Store. Inclui recursos avançados como lembretes, integração com calendário, estatísticas, filtros por comunidade, busca avançada, comparação de feriados e visualizações aprimoradas do calendário.
+
+**Existe período de teste gratuito?**
+Sim. Tanto o plano mensal quanto o anual incluem um teste gratuito. **Importante:** lembre-se de cancelar *pelo menos 24 horas antes do término* se não quiser ser cobrado.
+
+**Posso compartilhar minha assinatura com minha família?**
+Sim, através do Compartilhamento Familiar da Apple, sem custo adicional, desde que esteja devidamente configurado na sua conta da App Store.
+
+## Contato
+
+Se quiser entrar em contato diretamente ou deixar um comentário público, participe da seção [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Sua mensagem não será perdida.** O Holidays é um projeto pessoal, portanto eu leio pessoalmente todas as mensagens e sugestões.
+Além disso, seu email é usado apenas para responder à sua solicitação.

--- a/docs/pt/termos-e-condicoes.md
+++ b/docs/pt/termos-e-condicoes.md
@@ -1,0 +1,84 @@
+# Termos e condições de uso
+
+**Atualização mais recente: maio de 2025**
+
+*Ao baixar ou usar o aplicativo, você concorda com estes termos.*
+
+Estes termos regem o uso do **Holidays**, um aplicativo iOS desenvolvido por **Lucas Di Tomase** para exibir os feriados oficiais da Argentina. Você recebe uma **licença limitada, não exclusiva, intransferível e revogável** para usar o aplicativo para fins pessoais.
+
+## Uso do aplicativo
+
+O Holidays destina-se apenas ao **uso pessoal e não comercial**. Não pode ser utilizado para obter lucro, revendido ou incorporado a outro produto ou serviço.
+
+## Conteúdo
+
+As informações exibidas no aplicativo provêm de fontes públicas e podem sofrer alterações. Embora sejam atualizadas regularmente, **não há garantia de exatidão, integralidade ou atualidade das informações.**
+
+## Recursos e assinaturas
+
+O Holidays oferece recursos básicos gratuitos, incluindo:
+
+• Exibição de feriados nacionais, turísticos e religiosos
+• Filtros por tipo de feriado
+• Agenda semanal dos próximos feriados
+• Busca por nome ou motivo
+
+Recursos avançados estão disponíveis por meio de uma assinatura chamada **Holidays Pro**, que inclui:
+
+• Filtros por comunidade específica (muçulmana, judaica, armênia)
+• Adicionar feriados ao seu calendário pessoal
+• Definir lembretes automáticos
+• Estatísticas visuais e comparações
+• Visualização de feriados prolongados
+• Busca avançada por dia da semana ou mês
+• Vistas mensais e semanais do calendário
+
+## Assinaturas e período de teste
+
+• As assinaturas do Holidays Pro **renovam-se automaticamente** a menos que sejam canceladas **pelo menos 24 horas antes** do fim do período atual
+• O pagamento é cobrado do ID Apple utilizado na compra
+• Se houver **período de teste gratuito**, a assinatura começará automaticamente ao fim do teste, a menos que seja cancelada com 24 horas de antecedência
+• A gestão e o cancelamento da assinatura devem ser feitos nas configurações da sua conta da App Store
+• **Os preços podem variar** dependendo da região, data de compra e outras condições definidas pela Apple ou por mim como desenvolvedor. Os preços podem ser atualizados no futuro; nesse caso você será notificado antes da renovação automática para decidir se deseja continuar
+
+## Compartilhamento familiar
+
+Se você participa de um grupo de Compartilhamento Familiar do iCloud, poderá compartilhar sua assinatura com outros membros, desde que a opção esteja habilitada e configurada na sua conta da App Store. Este recurso depende do sistema operacional e das configurações individuais.
+
+## Atualizações
+
+O aplicativo pode receber atualizações periódicas com melhorias de desempenho, correções de bugs ou novos recursos sem aviso prévio.
+
+## Feedback e sugestões
+
+Quaisquer sugestões, comentários ou ideias enviados podem ser usados para melhorar o aplicativo, sem obrigação de compensação ou atribuição.
+
+## Propriedade intelectual
+
+Todo o conteúdo, interfaces, gráficos, código-fonte e recursos do Holidays são propriedade exclusiva do desenvolvedor, salvo indicação em contrário. Nenhum direito de propriedade intelectual é concedido ao usuário pelo uso do aplicativo.
+
+## Restrições técnicas
+
+É proibido:
+
+• Vender, distribuir, hospedar ou explorar comercialmente o aplicativo sem autorização
+• Copiar ou usar o aplicativo para qualquer finalidade que não seja o uso pessoal e não comercial
+• Modificar, descompilar, fazer engenharia reversa ou tentar acessar o código-fonte
+• Utilizar automações, scripts ou outros métodos não autorizados para interagir com o aplicativo
+• Reservo-me o direito de bloquear o acesso ao aplicativo, total ou parcial, se for detectado uso indevido, incluindo comportamento abusivo (como enviar spam ao suporte técnico) ou se o dispositivo for modificado de forma que afete o funcionamento normal do app (por exemplo, dispositivos com jailbreak, ambientes não autorizados, uso de lojas de terceiros ou ferramentas que alterem o sistema de compras internas ou qualquer outro recurso)
+
+Esta lista não é exaustiva. Outros casos também podem justificar restrições se comprometerem a segurança, a integridade ou o objetivo do aplicativo.
+
+## Isenção de responsabilidade
+
+O uso do aplicativo é por sua conta e risco. **Nem o desenvolvedor (Lucas Di Tomase) nem o aplicativo garantem disponibilidade contínua ou absoluta exatidão do conteúdo e não se responsabilizam por decisões tomadas com base nas informações fornecidas.**
+
+## Privacidade
+
+Holidays não coleta dados pessoais nem usa serviços de terceiros para análise ou publicidade. Para mais detalhes, consulte a [Política de privacidade](https://lucasditomase.github.io/feriados/pt/politica-de-privacidade).
+
+## Contato
+
+Para perguntas, suporte ou sugestões, visite a seção [Discussions](https://github.com/lucasditomase/feriados/discussions).
+
+**Holidays é um projeto pessoal. Se você entrar em contato, lerei pessoalmente sua mensagem.**


### PR DESCRIPTION
## Summary
- replicate `docs/en` into Italian, Portuguese, French and German folders
- translate page contents and file names for each language
- remove binary files from localized docs and reference shared images

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6842c4ec8a94832a926e088592747db0