### PR TITLE
Fix docs image paths and bullet lines

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,4 +1,4 @@
-[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)
 
 # Holidays
 
@@ -8,31 +8,31 @@ Ideal, um lange Wochenenden zu planen, Urlaube zu organisieren oder einfach dein
 
 ## Hauptfunktionen (kostenlos)
 
-• Countdown bis zum nächsten Feiertag
-• Vollständiger Kalender: nationale, touristische und religiöse Feiertage
-• Filter nach Typ: feste, bewegliche, touristische oder arbeitsfreie Tage
-• Suche nach Name oder Anlass des Feiertags
-• Option, vergangene Feiertage auszublenden und sich auf kommende zu konzentrieren
-• Wochenagenda, um nahe Feiertage zu sehen
-• Moderne, klare Oberfläche, die sich an alle Geräte anpasst
+• Countdown bis zum nächsten Feiertag	
+• Vollständiger Kalender: nationale, touristische und religiöse Feiertage	
+• Filter nach Typ: feste, bewegliche, touristische oder arbeitsfreie Tage	
+• Suche nach Name oder Anlass des Feiertags	
+• Option, vergangene Feiertage auszublenden und sich auf kommende zu konzentrieren	
+• Wochenagenda, um nahe Feiertage zu sehen	
+• Moderne, klare Oberfläche, die sich an alle Geräte anpasst	
 
 ## Erweiterte Funktionen mit Holidays Pro
 
-• Füge Feiertage deinem persönlichen Kalender hinzu
-• Richte automatische Erinnerungen ein
-• Filter nach Gemeinschaft (muslimisch, jüdisch, armenisch)
-• Detaillierte Statistiken und interaktive Diagramme
-• Monatliche Vergleiche von Feiertagen
-• Anzeige von langen Wochenenden
-• Erweiterte Suche nach Wochentag oder Monat
-• Vollständiger Kalender mit Monats- und Wochenansicht
+• Füge Feiertage deinem persönlichen Kalender hinzu	
+• Richte automatische Erinnerungen ein	
+• Filter nach Gemeinschaft (muslimisch, jüdisch, armenisch)	
+• Detaillierte Statistiken und interaktive Diagramme	
+• Monatliche Vergleiche von Feiertagen	
+• Anzeige von langen Wochenenden	
+• Erweiterte Suche nach Wochentag oder Monat	
+• Vollständiger Kalender mit Monats- und Wochenansicht	
 
 **Holidays Pro** beinhaltet eine kostenlose Testphase. Um Kosten zu vermeiden, kündige mindestens 24 Stunden vor Ablauf der Testphase.
 
 ## Datenschutz und Bedingungen
 
-• [Datenschutzrichtlinie](https://lucasditomase.github.io/feriados/de/datenschutzrichtlinie)
-• [Nutzungsbedingungen](https://lucasditomase.github.io/feriados/de/nutzungsbedingungen)
+• [Datenschutzrichtlinie](https://lucasditomase.github.io/feriados/de/datenschutzrichtlinie)	
+• [Nutzungsbedingungen](https://lucasditomase.github.io/feriados/de/nutzungsbedingungen)	
 
 ## Unterstützung
 
@@ -44,6 +44,6 @@ Wenn du Fragen oder Vorschläge hast oder der Community beitreten möchtest, kan
 
 <p align="left">
   <a href="https://apps.apple.com/app/id6744455042">
-    <img src="../images/download-badge.svg" alt="Im App Store laden" height="60">
+    <img src="images/download-badge.svg" alt="Im App Store laden" height="60">
   </a>
 </p>

--- a/docs/de/nutzungsbedingungen.md
+++ b/docs/de/nutzungsbedingungen.md
@@ -18,28 +18,28 @@ Die angezeigten Informationen stammen aus öffentlichen Quellen und können sich
 
 Holidays bietet kostenlose Basisfunktionen, darunter:
 
-• Anzeige nationaler, touristischer und religiöser Feiertage
-• Filter nach Feiertagstyp
-• Wochenagenda bevorstehender Feiertage
-• Suche nach Name oder Anlass
+• Anzeige nationaler, touristischer und religiöser Feiertage	
+• Filter nach Feiertagstyp	
+• Wochenagenda bevorstehender Feiertage	
+• Suche nach Name oder Anlass	
 
 Erweiterte Funktionen sind über ein Abonnement namens **Holidays Pro** verfügbar und umfassen:
 
-• Gemeinschaftsspezifische Filter (muslimisch, jüdisch, armenisch)
-• Hinzufügen von Feiertagen zum persönlichen Kalender
-• Automatische Erinnerungen
-• Visuelle Statistiken und Vergleiche
-• Anzeige langer Wochenenden
-• Erweiterte Suche nach Wochentag oder Monat
-• Monats- und Wochenansichten des Kalenders
+• Gemeinschaftsspezifische Filter (muslimisch, jüdisch, armenisch)	
+• Hinzufügen von Feiertagen zum persönlichen Kalender	
+• Automatische Erinnerungen	
+• Visuelle Statistiken und Vergleiche	
+• Anzeige langer Wochenenden	
+• Erweiterte Suche nach Wochentag oder Monat	
+• Monats- und Wochenansichten des Kalenders	
 
 ## Abonnements und Testphase
 
-• Abonnements von Holidays Pro **verlängern sich automatisch**, sofern sie nicht **spätestens 24 Stunden vor** Ablauf der laufenden Periode gekündigt werden
-• Die Zahlung erfolgt über die Apple-ID, mit der der Kauf getätigt wurde
-• Wird eine **kostenlose Testphase** angeboten, beginnt das Abonnement automatisch nach deren Ende, sofern es nicht mindestens 24 Stunden vorher gekündigt wird
-• Verwaltung und Kündigung des Abonnements erfolgen in den Einstellungen deines App-Store-Kontos
-• **Preise können variieren** je nach Region, Kaufdatum und anderen von Apple oder mir als Entwickler festgelegten Bedingungen. Preise können zukünftig angepasst werden; in diesem Fall wirst du vor der automatischen Verlängerung informiert, um zu entscheiden, ob du fortfahren möchtest
+• Abonnements von Holidays Pro **verlängern sich automatisch**, sofern sie nicht **spätestens 24 Stunden vor** Ablauf der laufenden Periode gekündigt werden	
+• Die Zahlung erfolgt über die Apple-ID, mit der der Kauf getätigt wurde	
+• Wird eine **kostenlose Testphase** angeboten, beginnt das Abonnement automatisch nach deren Ende, sofern es nicht mindestens 24 Stunden vorher gekündigt wird	
+• Verwaltung und Kündigung des Abonnements erfolgen in den Einstellungen deines App-Store-Kontos	
+• **Preise können variieren** je nach Region, Kaufdatum und anderen von Apple oder mir als Entwickler festgelegten Bedingungen. Preise können zukünftig angepasst werden; in diesem Fall wirst du vor der automatischen Verlängerung informiert, um zu entscheiden, ob du fortfahren möchtest	
 
 ## Familienfreigabe
 
@@ -61,11 +61,11 @@ Sämtliche Inhalte, Oberflächen, Grafiken, Quellcodes und Funktionen von Holida
 
 Es ist untersagt:
 
-• Die App ohne Genehmigung zu verkaufen, zu vertreiben, zu hosten oder kommerziell zu nutzen
-• Die App zu kopieren oder anderweitig zu verwenden, außer für den persönlichen und nicht kommerziellen Gebrauch
-• Die App zu modifizieren, zu dekompilieren, Reverse Engineering durchzuführen oder zu versuchen, den Quellcode zu erlangen
-• Automatisierungen, Skripte oder andere nicht autorisierte Methoden zu verwenden, um mit der App zu interagieren
-• Ich behalte mir das Recht vor, den Zugriff auf die App ganz oder teilweise zu blockieren, wenn missbräuchliche Nutzung festgestellt wird, einschließlich belästigendem Verhalten (z. B. Spam an den Support) oder wenn das Gerät so verändert wird, dass die normale Funktionsweise der App beeinträchtigt wird (z. B. Jailbreak, nicht autorisierte Umgebungen, Nutzung von Drittanbieter-Stores oder Tools, die das In-App-Kaufsystem oder andere Funktionen verändern)
+• Die App ohne Genehmigung zu verkaufen, zu vertreiben, zu hosten oder kommerziell zu nutzen	
+• Die App zu kopieren oder anderweitig zu verwenden, außer für den persönlichen und nicht kommerziellen Gebrauch	
+• Die App zu modifizieren, zu dekompilieren, Reverse Engineering durchzuführen oder zu versuchen, den Quellcode zu erlangen	
+• Automatisierungen, Skripte oder andere nicht autorisierte Methoden zu verwenden, um mit der App zu interagieren	
+• Ich behalte mir das Recht vor, den Zugriff auf die App ganz oder teilweise zu blockieren, wenn missbräuchliche Nutzung festgestellt wird, einschließlich belästigendem Verhalten (z. B. Spam an den Support) oder wenn das Gerät so verändert wird, dass die normale Funktionsweise der App beeinträchtigt wird (z. B. Jailbreak, nicht autorisierte Umgebungen, Nutzung von Drittanbieter-Stores oder Tools, die das In-App-Kaufsystem oder andere Funktionen verändern)	
 
 Diese Liste ist nicht abschließend. Weitere Fälle können ebenfalls Einschränkungen rechtfertigen, wenn sie die Sicherheit, Integrität oder den Zweck der App gefährden.
 

--- a/docs/fr/conditions-generales.md
+++ b/docs/fr/conditions-generales.md
@@ -18,28 +18,28 @@ Les informations affichées dans l'application proviennent de sources publiques 
 
 Holidays offre gratuitement des fonctionnalités de base, notamment :
 
-• Affichage des jours fériés nationaux, touristiques et religieux
-• Filtres par type de férié
-• Agenda hebdomadaire des fériés à venir
-• Recherche par nom ou motif
+• Affichage des jours fériés nationaux, touristiques et religieux	
+• Filtres par type de férié	
+• Agenda hebdomadaire des fériés à venir	
+• Recherche par nom ou motif	
 
 Des fonctionnalités avancées sont disponibles via un abonnement appelé **Holidays Pro**, qui inclut :
 
-• Filtres par communauté spécifique (musulmane, juive, arménienne)
-• Ajout des fériés à votre calendrier personnel
-• Rappels automatiques
-• Statistiques visuelles et comparaisons
-• Visualisation des ponts
-• Recherche avancée par jour de la semaine ou mois
-• Vues mensuelles et hebdomadaires du calendrier
+• Filtres par communauté spécifique (musulmane, juive, arménienne)	
+• Ajout des fériés à votre calendrier personnel	
+• Rappels automatiques	
+• Statistiques visuelles et comparaisons	
+• Visualisation des ponts	
+• Recherche avancée par jour de la semaine ou mois	
+• Vues mensuelles et hebdomadaires du calendrier	
 
 ## Abonnements et période d'essai
 
-• Les abonnements à Holidays Pro **se renouvellent automatiquement** sauf annulation **au moins 24 heures avant** la fin de la période en cours
-• Le paiement est effectué via l'identifiant Apple utilisé pour l'achat
-• Si une **période d'essai gratuite** est proposée, l'abonnement commencera automatiquement à la fin de celle-ci sauf annulation au moins 24 heures à l'avance
-• La gestion et l'annulation de l'abonnement doivent être effectuées dans les réglages de votre compte App Store
-• **Les prix peuvent varier** selon la région, la date d'achat et d'autres conditions définies par Apple ou par moi en tant que développeur. Les prix peuvent être mis à jour à l'avenir ; dans ce cas vous serez informé avant le renouvellement automatique pour décider de continuer ou non
+• Les abonnements à Holidays Pro **se renouvellent automatiquement** sauf annulation **au moins 24 heures avant** la fin de la période en cours	
+• Le paiement est effectué via l'identifiant Apple utilisé pour l'achat	
+• Si une **période d'essai gratuite** est proposée, l'abonnement commencera automatiquement à la fin de celle-ci sauf annulation au moins 24 heures à l'avance	
+• La gestion et l'annulation de l'abonnement doivent être effectuées dans les réglages de votre compte App Store	
+• **Les prix peuvent varier** selon la région, la date d'achat et d'autres conditions définies par Apple ou par moi en tant que développeur. Les prix peuvent être mis à jour à l'avenir ; dans ce cas vous serez informé avant le renouvellement automatique pour décider de continuer ou non	
 
 ## Partage familial
 
@@ -61,11 +61,11 @@ Tout le contenu, les interfaces, les graphismes, le code source et les fonctionn
 
 Il est interdit :
 
-• De vendre, distribuer, héberger ou exploiter commercialement l'application sans autorisation
-• De copier ou d'utiliser l'application à toute fin autre que l'usage personnel et non commercial
-• De modifier, décompiler, faire de l'ingénierie inverse ou tenter d'accéder au code source
-• D'utiliser des automatisations, scripts ou autres méthodes non autorisées pour interagir avec l'application
-• Je me réserve le droit de bloquer l'accès à l'application, en tout ou en partie, en cas d'utilisation abusive, y compris un comportement agressif (par exemple l'envoi massif de courriels au support technique) ou si l'appareil est modifié de manière à affecter le fonctionnement normal de l'application (appareils jailbreakés, environnements non autorisés, utilisation de stores tiers ou d'outils modifiant les achats intégrés ou toute autre fonctionnalité)
+• De vendre, distribuer, héberger ou exploiter commercialement l'application sans autorisation	
+• De copier ou d'utiliser l'application à toute fin autre que l'usage personnel et non commercial	
+• De modifier, décompiler, faire de l'ingénierie inverse ou tenter d'accéder au code source	
+• D'utiliser des automatisations, scripts ou autres méthodes non autorisées pour interagir avec l'application	
+• Je me réserve le droit de bloquer l'accès à l'application, en tout ou en partie, en cas d'utilisation abusive, y compris un comportement agressif (par exemple l'envoi massif de courriels au support technique) ou si l'appareil est modifié de manière à affecter le fonctionnement normal de l'application (appareils jailbreakés, environnements non autorisés, utilisation de stores tiers ou d'outils modifiant les achats intégrés ou toute autre fonctionnalité)	
 
 Cette liste n'est pas exhaustive. D'autres cas peuvent également justifier des restrictions s'ils compromettent la sécurité, l'intégrité ou l'objectif de l'application.
 

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,4 +1,4 @@
-[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)
 
 # Holidays
 
@@ -8,31 +8,31 @@ Parfaite pour planifier les week-ends prolongés, organiser des vacances ou simp
 
 ## Fonctionnalités principales (gratuites)
 
-• Compte à rebours jusqu'au prochain jour férié
-• Calendrier complet : fériés nationaux, touristiques et religieux
-• Filtres par type : fixes, mobiles, touristiques ou jours non travaillés
-• Recherche par nom ou motif du férié
-• Option pour masquer les fériés passés et se concentrer sur les prochains
-• Agenda hebdomadaire pour voir les fériés proches
-• Interface moderne et claire adaptée à tous les appareils
+• Compte à rebours jusqu'au prochain jour férié	
+• Calendrier complet : fériés nationaux, touristiques et religieux	
+• Filtres par type : fixes, mobiles, touristiques ou jours non travaillés	
+• Recherche par nom ou motif du férié	
+• Option pour masquer les fériés passés et se concentrer sur les prochains	
+• Agenda hebdomadaire pour voir les fériés proches	
+• Interface moderne et claire adaptée à tous les appareils	
 
 ## Fonctionnalités avancées avec Holidays Pro
 
-• Ajoutez les fériés à votre calendrier personnel
-• Programmez des rappels automatiques
-• Filtres par communauté (musulmane, juive, arménienne)
-• Statistiques détaillées et graphiques interactifs
-• Comparaisons mensuelles des fériés
-• Visualisation des ponts
-• Recherche avancée par jour de la semaine ou par mois
-• Calendrier complet avec vues mensuelle et hebdomadaire
+• Ajoutez les fériés à votre calendrier personnel	
+• Programmez des rappels automatiques	
+• Filtres par communauté (musulmane, juive, arménienne)	
+• Statistiques détaillées et graphiques interactifs	
+• Comparaisons mensuelles des fériés	
+• Visualisation des ponts	
+• Recherche avancée par jour de la semaine ou par mois	
+• Calendrier complet avec vues mensuelle et hebdomadaire	
 
 **Holidays Pro** comprend une période d'essai gratuite. Pour éviter les frais, veillez à annuler au moins 24 heures avant la fin de l'essai.
 
 ## Politique de confidentialité et conditions
 
-• [Politique de confidentialité](https://lucasditomase.github.io/feriados/fr/politique-de-confidentialite)
-• [Conditions générales](https://lucasditomase.github.io/feriados/fr/conditions-generales)
+• [Politique de confidentialité](https://lucasditomase.github.io/feriados/fr/politique-de-confidentialite)	
+• [Conditions générales](https://lucasditomase.github.io/feriados/fr/conditions-generales)	
 
 ## Assistance
 
@@ -44,6 +44,6 @@ Si vous avez des questions, des suggestions ou souhaitez rejoindre la communaut�
 
 <p align="left">
   <a href="https://apps.apple.com/app/id6744455042">
-    <img src="../images/download-badge.svg" alt="Télécharger sur l'App Store" height="60">
+    <img src="images/download-badge.svg" alt="Télécharger sur l'App Store" height="60">
   </a>
 </p>

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -1,4 +1,4 @@
-[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)
 
 # Holidays
 
@@ -8,31 +8,31 @@ Perfetta per pianificare i ponti, organizzare le vacanze o semplicemente sfrutta
 
 ## Funzioni principali (gratuite)
 
-• Conto alla rovescia per la prossima festività
-• Calendario completo: festività nazionali, turistiche e religiose
-• Filtri per tipo: fisse, mobili, turistiche o non lavorative
-• Ricerca per nome o motivo della festività
-• Opzione per nascondere le festività passate e concentrarti su quelle future
-• Agenda settimanale per vedere le festività vicine
-• Interfaccia moderna e chiara adattabile a tutti i dispositivi
+• Conto alla rovescia per la prossima festività	
+• Calendario completo: festività nazionali, turistiche e religiose	
+• Filtri per tipo: fisse, mobili, turistiche o non lavorative	
+• Ricerca per nome o motivo della festività	
+• Opzione per nascondere le festività passate e concentrarti su quelle future	
+• Agenda settimanale per vedere le festività vicine	
+• Interfaccia moderna e chiara adattabile a tutti i dispositivi	
 
 ## Funzionalità avanzate con Holidays Pro
 
-• Aggiungi le festività al tuo calendario personale
-• Imposta promemoria automatici
-• Filtri per comunità (musulmana, ebraica, armena)
-• Statistiche dettagliate e grafici interattivi
-• Confronti mensili delle festività
-• Visualizzazione dei ponti
-• Ricerca avanzata per giorno della settimana o mese
-• Calendario completo con viste mensile e settimanale
+• Aggiungi le festività al tuo calendario personale	
+• Imposta promemoria automatici	
+• Filtri per comunità (musulmana, ebraica, armena)	
+• Statistiche dettagliate e grafici interattivi	
+• Confronti mensili delle festività	
+• Visualizzazione dei ponti	
+• Ricerca avanzata per giorno della settimana o mese	
+• Calendario completo con viste mensile e settimanale	
 
 **Holidays Pro** include una prova gratuita. Per evitare l'addebito, assicurati di annullarla almeno 24 ore prima della scadenza.
 
 ## Informativa sulla privacy e termini
 
-• [Informativa sulla privacy](https://lucasditomase.github.io/feriados/it/informativa-sulla-privacy)
-• [Termini e condizioni](https://lucasditomase.github.io/feriados/it/termini-e-condizioni)
+• [Informativa sulla privacy](https://lucasditomase.github.io/feriados/it/informativa-sulla-privacy)	
+• [Termini e condizioni](https://lucasditomase.github.io/feriados/it/termini-e-condizioni)	
 
 ## Supporto
 
@@ -44,6 +44,6 @@ Se hai domande, suggerimenti o vuoi partecipare alla community, sentiti libero d
 
 <p align="left">
   <a href="https://apps.apple.com/app/id6744455042">
-    <img src="../images/download-badge.svg" alt="Scarica sull'App Store" height="60">
+    <img src="images/download-badge.svg" alt="Scarica sull'App Store" height="60">
   </a>
 </p>

--- a/docs/it/termini-e-condizioni.md
+++ b/docs/it/termini-e-condizioni.md
@@ -18,28 +18,28 @@ Le informazioni visualizzate nell'app provengono da fonti pubbliche e possono su
 
 Holidays offre gratuitamente funzioni di base, tra cui:
 
-• Visualizzazione dei giorni festivi nazionali, turistici e religiosi
-• Filtri per tipo di festività
-• Agenda settimanale delle festività imminenti
-• Ricerca per nome o motivo
+• Visualizzazione dei giorni festivi nazionali, turistici e religiosi	
+• Filtri per tipo di festività	
+• Agenda settimanale delle festività imminenti	
+• Ricerca per nome o motivo	
 
 Funzioni avanzate sono disponibili tramite un abbonamento chiamato **Holidays Pro**, che include:
 
-• Filtri per comunità specifiche (musulmana, ebraica, armena)
-• Aggiunta dei festivi al tuo calendario personale
-• Promemoria automatici
-• Statistiche e confronti visivi
-• Visualizzazione dei ponti
-• Ricerca avanzata per giorno della settimana o mese
-• Viste mensili e settimanali del calendario
+• Filtri per comunità specifiche (musulmana, ebraica, armena)	
+• Aggiunta dei festivi al tuo calendario personale	
+• Promemoria automatici	
+• Statistiche e confronti visivi	
+• Visualizzazione dei ponti	
+• Ricerca avanzata per giorno della settimana o mese	
+• Viste mensili e settimanali del calendario	
 
 ## Abbonamenti e prova gratuita
 
-• Gli abbonamenti a Holidays Pro **si rinnovano automaticamente** a meno che non vengano cancellati **almeno 24 ore prima** della fine del periodo in corso
-• Il pagamento viene addebitato sull'ID Apple utilizzato per l'acquisto
-• Se è prevista una **prova gratuita**, l'abbonamento inizierà automaticamente al termine della prova a meno che non venga cancellato con almeno 24 ore di anticipo
-• La gestione e la cancellazione dell'abbonamento devono essere effettuate dalle impostazioni del tuo account App Store
-• **I prezzi possono variare** in base alla regione, alla data di acquisto e ad altre condizioni stabilite da Apple o da me come sviluppatore. I prezzi potranno essere aggiornati in futuro; in tal caso sarai avvisato prima del rinnovo automatico per decidere se continuare
+• Gli abbonamenti a Holidays Pro **si rinnovano automaticamente** a meno che non vengano cancellati **almeno 24 ore prima** della fine del periodo in corso	
+• Il pagamento viene addebitato sull'ID Apple utilizzato per l'acquisto	
+• Se è prevista una **prova gratuita**, l'abbonamento inizierà automaticamente al termine della prova a meno che non venga cancellato con almeno 24 ore di anticipo	
+• La gestione e la cancellazione dell'abbonamento devono essere effettuate dalle impostazioni del tuo account App Store	
+• **I prezzi possono variare** in base alla regione, alla data di acquisto e ad altre condizioni stabilite da Apple o da me come sviluppatore. I prezzi potranno essere aggiornati in futuro; in tal caso sarai avvisato prima del rinnovo automatico per decidere se continuare	
 
 ## Condivisione in famiglia
 
@@ -61,11 +61,11 @@ Tutti i contenuti, le interfacce, la grafica, il codice sorgente e le funzionali
 
 È vietato:
 
-• Vendere, distribuire, ospitare o sfruttare commercialmente l'app senza autorizzazione
-• Copiare o utilizzare l'app per scopi diversi dall'uso personale e non commerciale
-• Modificare, decompilare, fare reverse engineering o tentare di accedere al codice sorgente
-• Utilizzare automazioni, script o altri metodi non autorizzati per interagire con l'app
-• Mi riservo il diritto di bloccare l'accesso all'app, in tutto o in parte, se viene rilevato un uso improprio, compresi comportamenti abusivi (come lo spam al supporto tecnico) o se il dispositivo viene modificato in modo da compromettere il normale funzionamento dell'app (ad esempio dispositivi jailbroken, ambienti non autorizzati, utilizzo di store di terze parti o strumenti che alterano il sistema di acquisti in-app o altre funzioni)
+• Vendere, distribuire, ospitare o sfruttare commercialmente l'app senza autorizzazione	
+• Copiare o utilizzare l'app per scopi diversi dall'uso personale e non commerciale	
+• Modificare, decompilare, fare reverse engineering o tentare di accedere al codice sorgente	
+• Utilizzare automazioni, script o altri metodi non autorizzati per interagire con l'app	
+• Mi riservo il diritto di bloccare l'accesso all'app, in tutto o in parte, se viene rilevato un uso improprio, compresi comportamenti abusivi (come lo spam al supporto tecnico) o se il dispositivo viene modificato in modo da compromettere il normale funzionamento dell'app (ad esempio dispositivi jailbroken, ambienti non autorizzati, utilizzo di store di terze parti o strumenti che alterano il sistema di acquisti in-app o altre funzioni)	
 
 Questo elenco non è esaustivo. Altri casi potrebbero giustificare restrizioni se compromettono la sicurezza, l'integrità o lo scopo dell'app.
 

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,4 +1,4 @@
-[![Holidays App](../images/banner.png)](https://apps.apple.com/app/id6744455042)
+[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)
 
 # Holidays
 
@@ -8,31 +8,31 @@ Perfeito para planejar feriados prolongados, organizar férias ou simplesmente a
 
 ## Principais recursos (grátis)
 
-• Contagem regressiva para o próximo feriado
-• Calendário completo: feriados nacionais, turísticos e religiosos
-• Filtros por tipo: fixos, móveis, turísticos ou não laborais
-• Busca por nome ou motivo do feriado
-• Opção para ocultar feriados passados e focar nos próximos
-• Agenda semanal para ver os feriados próximos
-• Interface moderna e clara adaptável a todos os dispositivos
+• Contagem regressiva para o próximo feriado	
+• Calendário completo: feriados nacionais, turísticos e religiosos	
+• Filtros por tipo: fixos, móveis, turísticos ou não laborais	
+• Busca por nome ou motivo do feriado	
+• Opção para ocultar feriados passados e focar nos próximos	
+• Agenda semanal para ver os feriados próximos	
+• Interface moderna e clara adaptável a todos os dispositivos	
 
 ## Recursos avançados com Holidays Pro
 
-• Adicione feriados ao seu calendário pessoal
-• Defina lembretes automáticos
-• Filtros por comunidade (muçulmana, judaica, armênia)
-• Estatísticas detalhadas e gráficos interativos
-• Comparativos mensais de feriados
-• Visualização de feriados prolongados
-• Busca avançada por dia da semana ou mês
-• Calendário completo com vistas mensal e semanal
+• Adicione feriados ao seu calendário pessoal	
+• Defina lembretes automáticos	
+• Filtros por comunidade (muçulmana, judaica, armênia)	
+• Estatísticas detalhadas e gráficos interativos	
+• Comparativos mensais de feriados	
+• Visualização de feriados prolongados	
+• Busca avançada por dia da semana ou mês	
+• Calendário completo com vistas mensal e semanal	
 
 **Holidays Pro** inclui um período de teste gratuito. Para evitar cobranças, cancele pelo menos 24 horas antes do fim do período.
 
 ## Política de privacidade e termos
 
-• [Política de privacidade](https://lucasditomase.github.io/feriados/pt/politica-de-privacidade)
-• [Termos e condições](https://lucasditomase.github.io/feriados/pt/termos-e-condicoes)
+• [Política de privacidade](https://lucasditomase.github.io/feriados/pt/politica-de-privacidade)	
+• [Termos e condições](https://lucasditomase.github.io/feriados/pt/termos-e-condicoes)	
 
 ## Suporte
 
@@ -44,6 +44,6 @@ Se você tiver dúvidas, sugestões ou quiser participar da comunidade, fique à
 
 <p align="left">
   <a href="https://apps.apple.com/app/id6744455042">
-    <img src="../images/download-badge.svg" alt="Baixar na App Store" height="60">
+    <img src="images/download-badge.svg" alt="Baixar na App Store" height="60">
   </a>
 </p>

--- a/docs/pt/termos-e-condicoes.md
+++ b/docs/pt/termos-e-condicoes.md
@@ -18,28 +18,28 @@ As informações exibidas no aplicativo provêm de fontes públicas e podem sofr
 
 O Holidays oferece recursos básicos gratuitos, incluindo:
 
-• Exibição de feriados nacionais, turísticos e religiosos
-• Filtros por tipo de feriado
-• Agenda semanal dos próximos feriados
-• Busca por nome ou motivo
+• Exibição de feriados nacionais, turísticos e religiosos	
+• Filtros por tipo de feriado	
+• Agenda semanal dos próximos feriados	
+• Busca por nome ou motivo	
 
 Recursos avançados estão disponíveis por meio de uma assinatura chamada **Holidays Pro**, que inclui:
 
-• Filtros por comunidade específica (muçulmana, judaica, armênia)
-• Adicionar feriados ao seu calendário pessoal
-• Definir lembretes automáticos
-• Estatísticas visuais e comparações
-• Visualização de feriados prolongados
-• Busca avançada por dia da semana ou mês
-• Vistas mensais e semanais do calendário
+• Filtros por comunidade específica (muçulmana, judaica, armênia)	
+• Adicionar feriados ao seu calendário pessoal	
+• Definir lembretes automáticos	
+• Estatísticas visuais e comparações	
+• Visualização de feriados prolongados	
+• Busca avançada por dia da semana ou mês	
+• Vistas mensais e semanais do calendário	
 
 ## Assinaturas e período de teste
 
-• As assinaturas do Holidays Pro **renovam-se automaticamente** a menos que sejam canceladas **pelo menos 24 horas antes** do fim do período atual
-• O pagamento é cobrado do ID Apple utilizado na compra
-• Se houver **período de teste gratuito**, a assinatura começará automaticamente ao fim do teste, a menos que seja cancelada com 24 horas de antecedência
-• A gestão e o cancelamento da assinatura devem ser feitos nas configurações da sua conta da App Store
-• **Os preços podem variar** dependendo da região, data de compra e outras condições definidas pela Apple ou por mim como desenvolvedor. Os preços podem ser atualizados no futuro; nesse caso você será notificado antes da renovação automática para decidir se deseja continuar
+• As assinaturas do Holidays Pro **renovam-se automaticamente** a menos que sejam canceladas **pelo menos 24 horas antes** do fim do período atual	
+• O pagamento é cobrado do ID Apple utilizado na compra	
+• Se houver **período de teste gratuito**, a assinatura começará automaticamente ao fim do teste, a menos que seja cancelada com 24 horas de antecedência	
+• A gestão e o cancelamento da assinatura devem ser feitos nas configurações da sua conta da App Store	
+• **Os preços podem variar** dependendo da região, data de compra e outras condições definidas pela Apple ou por mim como desenvolvedor. Os preços podem ser atualizados no futuro; nesse caso você será notificado antes da renovação automática para decidir se deseja continuar	
 
 ## Compartilhamento familiar
 
@@ -61,11 +61,11 @@ Todo o conteúdo, interfaces, gráficos, código-fonte e recursos do Holidays s�
 
 É proibido:
 
-• Vender, distribuir, hospedar ou explorar comercialmente o aplicativo sem autorização
-• Copiar ou usar o aplicativo para qualquer finalidade que não seja o uso pessoal e não comercial
-• Modificar, descompilar, fazer engenharia reversa ou tentar acessar o código-fonte
-• Utilizar automações, scripts ou outros métodos não autorizados para interagir com o aplicativo
-• Reservo-me o direito de bloquear o acesso ao aplicativo, total ou parcial, se for detectado uso indevido, incluindo comportamento abusivo (como enviar spam ao suporte técnico) ou se o dispositivo for modificado de forma que afete o funcionamento normal do app (por exemplo, dispositivos com jailbreak, ambientes não autorizados, uso de lojas de terceiros ou ferramentas que alterem o sistema de compras internas ou qualquer outro recurso)
+• Vender, distribuir, hospedar ou explorar comercialmente o aplicativo sem autorização	
+• Copiar ou usar o aplicativo para qualquer finalidade que não seja o uso pessoal e não comercial	
+• Modificar, descompilar, fazer engenharia reversa ou tentar acessar o código-fonte	
+• Utilizar automações, scripts ou outros métodos não autorizados para interagir com o aplicativo	
+• Reservo-me o direito de bloquear o acesso ao aplicativo, total ou parcial, se for detectado uso indevido, incluindo comportamento abusivo (como enviar spam ao suporte técnico) ou se o dispositivo for modificado de forma que afete o funcionamento normal do app (por exemplo, dispositivos com jailbreak, ambientes não autorizados, uso de lojas de terceiros ou ferramentas que alterem o sistema de compras internas ou qualquer outro recurso)	
 
 Esta lista não é exaustiva. Outros casos também podem justificar restrições se comprometerem a segurança, a integridade ou o objetivo do aplicativo.
 


### PR DESCRIPTION
## Summary
- fix relative paths for banner and download images in localized docs
- add trailing tabs on bullet lines in localized docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842cf6693f4832aa5a15e815a74e8ae