### PR TITLE
Fix localized app name references in docs

### DIFF
--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -1,11 +1,11 @@
-[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+[![Feiertage App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
   
-# Holidays  
+# Feiertage  
   
-Holidays: deine freie Zeit, gut genutzt.  
+Feiertage: deine freie Zeit, gut genutzt.  
   
 Die einfachste, klarste und leistungsstärkste Art, die Feiertage in Argentinien nachzuschlagen.  
-Mit modernem Design und Funktionen für den Alltag hilft dir Holidays, Kurztrips und Urlaube zu planen oder einfach deine Wochenenden mehr zu genießen.  
+Mit modernem Design und Funktionen für den Alltag hilft dir Feiertage, Kurztrips und Urlaube zu planen oder einfach deine Wochenenden mehr zu genießen.  
   
 Prüfe in Sekundenschnelle den nächsten Feiertag, erkunde den kompletten Kalender und filtere arbeitsfreie Tage nach deinen Interessen, Überzeugungen oder deinem Lebensstil.  
   
@@ -21,7 +21,7 @@ Ideal für Studierende, Berufstätige, Familien und alle, die ihre freien Tage b
 • Wochenagenda, um nahe Feiertage zu sehen  
 • Moderne, klare Oberfläche, die sich an alle Geräte anpasst  
   
-## Erweiterte Funktionen mit Holidays Pro  
+## Erweiterte Funktionen mit Feiertage Pro  
   
 • Füge Feiertage deinem persönlichen Kalender hinzu  
 • Erhalte Benachrichtigungen vor jedem Feiertag  
@@ -32,7 +32,7 @@ Ideal für Studierende, Berufstätige, Familien und alle, die ihre freien Tage b
 • Erweiterte Suche nach Wochentag oder Monat  
 • Detaillierte Monats- und Wochenansicht des Kalenders  
   
-**Holidays Pro** beinhaltet eine kostenlose Testphase. Kündige mindestens 24 Stunden vor Ablauf, wenn du keine Kosten möchtest.  
+**Feiertage Pro** beinhaltet eine kostenlose Testphase. Kündige mindestens 24 Stunden vor Ablauf, wenn du keine Kosten möchtest.  
   
 ## Datenschutz und Bedingungen  
   
@@ -45,7 +45,7 @@ Wenn du Fragen oder Vorschläge hast oder der Community beitreten möchtest, kan
   
 ---  
   
-*Holidays ist ein Privatprojekt. Danke, dass du unabhängige Entwickler unterstützt.*  
+*Feiertage ist ein Privatprojekt. Danke, dass du unabhängige Entwickler unterstützt.*  
   
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  

--- a/docs/de/privacy-policy.md
+++ b/docs/de/privacy-policy.md
@@ -2,20 +2,20 @@
   
 **Letzte Aktualisierung: Mai 2025**  
   
-**Holidays ist eine App, die deine Privatsphäre respektiert:** *sie sammelt, speichert oder teilt keinerlei persönliche Nutzerdaten.*  
+**Feiertage ist eine App, die deine Privatsphäre respektiert:** *sie sammelt, speichert oder teilt keinerlei persönliche Nutzerdaten.*  
   
 ## Datenerfassung  
   
 Die App verlangt keine unnötigen Berechtigungen und greift nicht auf sensible Daten zu.  
 Alle angezeigten Informationen (nationale, touristische und religiöse Feiertage) sind öffentlich und werden lokal auf dem Gerät des Nutzers gespeichert.  
   
-Die zusätzlichen Funktionen von Holidays Pro, wie Feiertagsstatistiken und Vergleiche, werden lokal auf deinem Gerät erzeugt und verarbeitet. Es werden keine Daten an externe Server gesendet oder dort gespeichert.  
+Die zusätzlichen Funktionen von Feiertage Pro, wie Feiertagsstatistiken und Vergleiche, werden lokal auf deinem Gerät erzeugt und verarbeitet. Es werden keine Daten an externe Server gesendet oder dort gespeichert.  
   
 ## In-App-Käufe und kostenlose Testphase  
   
-Die App bietet Abonnements über den App Store an. Alle Zahlungen, Testphasen und die Verwaltung des Abonnements erfolgen ausschließlich über Apple. **Holidays hat zu keinem Zeitpunkt Zugriff auf persönliche, finanzielle oder Abrechnungsdaten.**  
+Die App bietet Abonnements über den App Store an. Alle Zahlungen, Testphasen und die Verwaltung des Abonnements erfolgen ausschließlich über Apple. **Feiertage hat zu keinem Zeitpunkt Zugriff auf persönliche, finanzielle oder Abrechnungsdaten.**  
   
-Wenn eine Testphase verfügbar ist, kannst du Holidays Pro während dieser Zeit kostenlos nutzen. Die Gebühren werden automatisch am Ende der Testphase berechnet, **sofern du das Abonnement nicht mindestens 24 Stunden vorher über dein App-Store-Konto kündigst.**  
+Wenn eine Testphase verfügbar ist, kannst du Feiertage Pro während dieser Zeit kostenlos nutzen. Die Gebühren werden automatisch am Ende der Testphase berechnet, **sofern du das Abonnement nicht mindestens 24 Stunden vorher über dein App-Store-Konto kündigst.**  
   
 ## Optionale Berechtigungen  
   
@@ -27,7 +27,7 @@ Wenn du einen Feiertag in deinen Kalender einfügst, wird ein einzelnes Ereignis
   
 ## Drittanbieter  
   
-Holidays verwendet keine Drittanbieterdienste für Analysen, Werbung oder Datenspeicherung.  
+Feiertage verwendet keine Drittanbieterdienste für Analysen, Werbung oder Datenspeicherung.  
   
 ## Kontakt per E-Mail  
   
@@ -39,4 +39,4 @@ Diese Daten werden ausschließlich verwendet, um auf deine Anfrage zu antworten.
   
 Wenn du Fragen zu dieser Richtlinie hast, schreib gern im Bereich [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays ist ein Privatprojekt. Alle Anfragen werden gelesen und geschätzt.**  
+**Feiertage ist ein Privatprojekt. Alle Anfragen werden gelesen und geschätzt.**  

--- a/docs/de/support.md
+++ b/docs/de/support.md
@@ -1,43 +1,43 @@
-# Unterstützung für Holidays  
+# Unterstützung für Feiertage  
   
-Vielen Dank, dass du Holidays verwendest. Wenn du Fehler findest, Fragen hast oder Verbesserungen vorschlagen möchtest, kontaktiere mich gern oder beteilige dich an diesem Repository.  
+Vielen Dank, dass du Feiertage verwendest. Wenn du Fehler findest, Fragen hast oder Verbesserungen vorschlagen möchtest, kontaktiere mich gern oder beteilige dich an diesem Repository.  
 Dies ist ein Privatprojekt, daher ist jedes Feedback oder jeder Beitrag sehr willkommen.  
   
 ## Ein Problem melden  
   
 Du kannst ein Issue in diesem Repository eröffnen und das Problem sowie die Schritte zur Reproduktion beschreiben. Wenn möglich, füge einen Screenshot bei.  
   
-[Issue erstellen](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20mit%20Holidays%20App&body=Beschreibe%20das%20Problem%2C%20das%20du%20festgestellt%20hast%3A%0A%0A-%20Gerät%3A%20%0A-%20iOS-Version%3A%20%0A-%20App-Version%3A%20%0A-%20Schritte%20zur%20Reproduktion%3A%0A%0A(Optional)%20Füge%20einen%20Screenshot%20oder%20eine%20Aufnahme%20hinzu%2C%20wenn%20möglich.)  
+[Issue erstellen](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20mit%20Feiertage%20App&body=Beschreibe%20das%20Problem%2C%20das%20du%20festgestellt%20hast%3A%0A%0A-%20Gerät%3A%20%0A-%20iOS-Version%3A%20%0A-%20App-Version%3A%20%0A-%20Schritte%20zur%20Reproduktion%3A%0A%0A(Optional)%20Füge%20einen%20Screenshot%20oder%20eine%20Aufnahme%20hinzu%2C%20wenn%20möglich.)  
   
 Du kannst mich auch per E-Mail kontaktieren, wenn du GitHub nicht verwenden möchtest. In der App gibt es unter "Weitere Infos" eine Option, eine E-Mail mit allen technischen Details zu senden (Gerätemodell, Sprache, iOS-Version usw.).  
   
 ## Häufig gestellte Fragen  
   
 **Kann ich Feiertage meinem Kalender hinzufügen?**  
-Ja, mit Holidays Pro kannst du jeden Feiertag direkt in deinen persönlichen Kalender eintragen.  
+Ja, mit Feiertage Pro kannst du jeden Feiertag direkt in deinen persönlichen Kalender eintragen.  
   
 **Kann ich Erinnerungen für Feiertage einstellen?**  
-Ja, Holidays Pro erlaubt es, Erinnerungen einzurichten, damit du vor jedem Feiertag benachrichtigt wirst.  
+Ja, Feiertage Pro erlaubt es, Erinnerungen einzurichten, damit du vor jedem Feiertag benachrichtigt wirst.  
   
 **Was bietet die kostenlose Version?**  
 Sie enthält den kompletten Kalender nationaler, touristischer und religiöser Feiertage, eine Wochenagenda und einfache Filter nach Feiertagstyp.  
   
-**Welche Extras bietet Holidays Pro?**  
+**Welche Extras bietet Feiertage Pro?**  
 Es beinhaltet Erinnerungen, das Hinzufügen von Feiertagen zum Kalender, Vergleichsstatistiken, Filter nach Gemeinschaft, erweiterte Suche und verbesserte Kalenderansichten.  
   
 **Warum gibt es religiöse Feiertage?**  
-Holidays ermöglicht das Filtern nach Gemeinschaft (muslimisch, jüdisch, armenisch), damit jeder Nutzer relevante Daten entsprechend seinen Vorlieben sehen kann.  
+Feiertage ermöglicht das Filtern nach Gemeinschaft (muslimisch, jüdisch, armenisch), damit jeder Nutzer relevante Daten entsprechend seinen Vorlieben sehen kann.  
   
 **Sind die Feiertage immer aktuell?**  
 Die Informationen stammen aus offiziellen Quellen und werden regelmäßig aktualisiert. Dennoch können unerwartete Änderungen durch Regierungsentscheidungen oder menschliche Fehler auftreten.  
   
 **Sammelt die App personenbezogene Daten?**  
-Nein. Holidays speichert oder überträgt keine Nutzerdaten. Alles geschieht lokal auf deinem Gerät.  
+Nein. Feiertage speichert oder überträgt keine Nutzerdaten. Alles geschieht lokal auf deinem Gerät.  
   
 **Was passiert, wenn ich eine E-Mail aus der App sende?**  
 Du teilst deine E-Mail-Adresse und den in deinem Konto hinterlegten Namen. Diese Informationen werden nur verwendet, um auf deine Nachricht zu antworten. **Sie werden niemals weitergegeben oder verkauft.**  
   
-**Wie funktioniert Holidays Pro?**  
+**Wie funktioniert Feiertage Pro?**  
 Es handelt sich um ein optionales Abonnement, das du über dein App-Store-Konto aktivieren oder kündigen kannst. Es umfasst erweiterte Funktionen wie Erinnerungen, Kalenderintegration, Statistiken, Gemeinschaftsfilter, erweiterte Suche, Feiertagsvergleiche und verbesserte Kalenderansichten.  
   
 **Gibt es eine kostenlose Testphase?**  
@@ -50,5 +50,5 @@ Ja, über Apple Family Sharing ohne zusätzliche Kosten, vorausgesetzt es ist in
   
 Wenn du direkt Kontakt aufnehmen oder einen öffentlichen Kommentar hinterlassen möchtest, besuche den Bereich [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Deine Nachricht geht nicht verloren.** Holidays ist ein Privatprojekt, daher lese ich alle Nachrichten und Vorschläge persönlich.  
+**Deine Nachricht geht nicht verloren.** Feiertage ist ein Privatprojekt, daher lese ich alle Nachrichten und Vorschläge persönlich.  
 Außerdem wird deine E-Mail-Adresse nur benutzt, um auf deine Anfrage zu antworten.  

--- a/docs/de/terms-and-conditions.md
+++ b/docs/de/terms-and-conditions.md
@@ -4,11 +4,11 @@
   
 *Durch das Herunterladen oder Verwenden der App stimmst du diesen Bedingungen zu.*  
   
-Diese Bedingungen regeln die Nutzung von **Holidays**, einer iOS-App von **Lucas Di Tomase**, die offizielle Feiertage in Argentinien anzeigt. Dir wird eine **beschränkte, nicht exklusive, nicht übertragbare und widerrufliche Lizenz** zur persönlichen Nutzung der App erteilt.  
+Diese Bedingungen regeln die Nutzung von **Feiertage**, einer iOS-App von **Lucas Di Tomase**, die offizielle Feiertage in Argentinien anzeigt. Dir wird eine **beschränkte, nicht exklusive, nicht übertragbare und widerrufliche Lizenz** zur persönlichen Nutzung der App erteilt.  
   
 ## Nutzung der App  
   
-Holidays ist ausschließlich für den **persönlichen, nicht kommerziellen Gebrauch** bestimmt. Sie darf nicht zum Profit, Weiterverkauf oder als Teil eines anderen Produkts oder Dienstes verwendet werden.  
+Feiertage ist ausschließlich für den **persönlichen, nicht kommerziellen Gebrauch** bestimmt. Sie darf nicht zum Profit, Weiterverkauf oder als Teil eines anderen Produkts oder Dienstes verwendet werden.  
   
 ## Inhalt  
   
@@ -16,14 +16,14 @@ Die angezeigten Informationen stammen aus öffentlichen Quellen und können sich
   
 ## Funktionen und Abonnements  
   
-Holidays bietet kostenlose Basisfunktionen, darunter:  
+Feiertage bietet kostenlose Basisfunktionen, darunter:  
   
 • Anzeige nationaler, touristischer und religiöser Feiertage  
 • Filter nach Feiertagstyp  
 • Wochenagenda bevorstehender Feiertage  
 • Suche nach Name oder Anlass  
   
-Erweiterte Funktionen sind über ein Abonnement namens **Holidays Pro** verfügbar und umfassen:  
+Erweiterte Funktionen sind über ein Abonnement namens **Feiertage Pro** verfügbar und umfassen:  
   
 • Gemeinschaftsspezifische Filter (muslimisch, jüdisch, armenisch)  
 • Hinzufügen von Feiertagen zum persönlichen Kalender  
@@ -35,7 +35,7 @@ Erweiterte Funktionen sind über ein Abonnement namens **Holidays Pro** verfügb
   
 ## Abonnements und Testphase  
   
-• Abonnements von Holidays Pro **verlängern sich automatisch**, sofern sie nicht **spätestens 24 Stunden vor** Ablauf der laufenden Periode gekündigt werden  
+• Abonnements von Feiertage Pro **verlängern sich automatisch**, sofern sie nicht **spätestens 24 Stunden vor** Ablauf der laufenden Periode gekündigt werden  
 • Die Zahlung erfolgt über die Apple-ID, mit der der Kauf getätigt wurde  
 • Wird eine **kostenlose Testphase** angeboten, beginnt das Abonnement automatisch nach deren Ende, sofern es nicht mindestens 24 Stunden vorher gekündigt wird  
 • Verwaltung und Kündigung des Abonnements erfolgen in den Einstellungen deines App-Store-Kontos  
@@ -55,7 +55,7 @@ Jegliche Vorschläge, Kommentare oder Ideen können zur Verbesserung der App ver
   
 ## Geistiges Eigentum  
   
-Sämtliche Inhalte, Oberflächen, Grafiken, Quellcodes und Funktionen von Holidays sind, sofern nicht anders angegeben, alleiniges Eigentum des Entwicklers. Durch die Nutzung der App werden keine Rechte am geistigen Eigentum eingeräumt.  
+Sämtliche Inhalte, Oberflächen, Grafiken, Quellcodes und Funktionen von Feiertage sind, sofern nicht anders angegeben, alleiniges Eigentum des Entwicklers. Durch die Nutzung der App werden keine Rechte am geistigen Eigentum eingeräumt.  
   
 ## Technische Einschränkungen  
   
@@ -79,10 +79,10 @@ Die Nutzung der App erfolgt auf eigenes Risiko. **Weder der Entwickler (Lucas Di
   
 ## Datenschutz  
   
-Holidays erhebt keine personenbezogenen Daten und verwendet keine Dienste Dritter für Analysen oder Werbung. Weitere Informationen findest du in der [Datenschutzrichtlinie](https://lucasditomase.github.io/feriados/de/privacy-policy).  
+Feiertage erhebt keine personenbezogenen Daten und verwendet keine Dienste Dritter für Analysen oder Werbung. Weitere Informationen findest du in der [Datenschutzrichtlinie](https://lucasditomase.github.io/feriados/de/privacy-policy).  
   
 ## Kontakt  
   
 Bei Fragen, Unterstützung oder Vorschlägen besuche den Bereich [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays ist ein Privatprojekt. Wenn du dich meldest, lese ich deine Nachricht persönlich.**  
+**Feiertage ist ein Privatprojekt. Wenn du dich meldest, lese ich deine Nachricht persönlich.**  

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -1,11 +1,11 @@
-[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+[![Jours Fériés App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
   
-# Holidays  
+# Jours Fériés  
   
-Holidays : votre temps libre, bien utilisé.  
+Jours Fériés : votre temps libre, bien utilisé.  
   
 La façon la plus simple, claire et puissante de consulter les jours fériés en Argentine.  
-Avec un design moderne et des fonctionnalités pensées pour le quotidien, Holidays vous aide à planifier des escapades, des vacances ou simplement à mieux profiter de vos week-ends.  
+Avec un design moderne et des fonctionnalités pensées pour le quotidien, Jours Fériés vous aide à planifier des escapades, des vacances ou simplement à mieux profiter de vos week-ends.  
   
 Consultez en quelques secondes la date du prochain férié, explorez le calendrier complet et filtrez les jours non travaillés selon vos intérêts, croyances ou mode de vie.  
   
@@ -21,7 +21,7 @@ Idéal pour les étudiants, les travailleurs, les familles et toute personne sou
 • Agenda hebdomadaire pour voir les fériés proches  
 • Interface moderne et claire adaptée à tous les appareils  
   
-## Fonctionnalités avancées avec Holidays Pro  
+## Fonctionnalités avancées avec Jours Fériés Pro  
   
 • Ajoutez les fériés à votre calendrier personnel  
 • Recevez des notifications avant chaque férié  
@@ -32,7 +32,7 @@ Idéal pour les étudiants, les travailleurs, les familles et toute personne sou
 • Recherche avancée par jour de la semaine ou par mois  
 • Vue mensuelle et hebdomadaire détaillée du calendrier  
   
-**Holidays Pro** comprend une période d'essai gratuite. Annulez au moins 24 heures avant la fin si vous ne souhaitez pas être facturé.  
+**Jours Fériés Pro** comprend une période d'essai gratuite. Annulez au moins 24 heures avant la fin si vous ne souhaitez pas être facturé.  
   
 ## Politique de confidentialité et conditions  
   
@@ -45,7 +45,7 @@ Si vous avez des questions, des suggestions ou souhaitez rejoindre la communaut�
   
 ---  
   
-*Holidays est un projet personnel. Merci de soutenir les développeurs indépendants.*  
+*Jours Fériés est un projet personnel. Merci de soutenir les développeurs indépendants.*  
   
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  

--- a/docs/fr/privacy-policy.md
+++ b/docs/fr/privacy-policy.md
@@ -2,20 +2,20 @@
   
 **Dernière mise à jour : mai 2025**  
   
-**Holidays est une application qui respecte votre vie privée :** *elle ne collecte, ne stocke ni ne partage aucune information personnelle des utilisateurs.*  
+**Jours Fériés est une application qui respecte votre vie privée :** *elle ne collecte, ne stocke ni ne partage aucune information personnelle des utilisateurs.*  
   
 ## Collecte de données  
   
 L'application ne demande pas d'autorisations inutiles et n'accède pas à des données sensibles.  
 Toutes les informations affichées (fériés nationaux, touristiques et religieux) sont publiques et stockées localement sur l'appareil de l'utilisateur.  
   
-Les fonctionnalités supplémentaires de Holidays Pro, telles que les statistiques et comparaisons de fériés, sont générées et traitées localement sur votre appareil. Aucune information n'est envoyée ou stockée sur des serveurs externes.  
+Les fonctionnalités supplémentaires de Jours Fériés Pro, telles que les statistiques et comparaisons de fériés, sont générées et traitées localement sur votre appareil. Aucune information n'est envoyée ou stockée sur des serveurs externes.  
   
 ## Achats intégrés et période d'essai gratuite  
   
-L'application propose des abonnements via l'App Store. Tout le traitement des paiements, les périodes d'essai et la gestion des abonnements sont assurés exclusivement par Apple. **Holidays n'accède jamais à vos informations personnelles, financières ou de facturation.**  
+L'application propose des abonnements via l'App Store. Tout le traitement des paiements, les périodes d'essai et la gestion des abonnements sont assurés exclusivement par Apple. **Jours Fériés n'accède jamais à vos informations personnelles, financières ou de facturation.**  
   
-S'il existe une période d'essai, vous pourrez utiliser Holidays Pro sans frais pendant cette durée. Vous serez facturé automatiquement à la fin de l'essai, **sauf si vous annulez l'abonnement au moins 24 heures à l'avance** depuis votre compte App Store.  
+S'il existe une période d'essai, vous pourrez utiliser Jours Fériés Pro sans frais pendant cette durée. Vous serez facturé automatiquement à la fin de l'essai, **sauf si vous annulez l'abonnement au moins 24 heures à l'avance** depuis votre compte App Store.  
   
 ## Permissions optionnelles  
   
@@ -27,7 +27,7 @@ Si vous choisissez d'ajouter un férié à votre calendrier, un seul événement
   
 ## Tiers  
   
-Holidays n'utilise aucun service tiers pour l'analyse, la publicité ou le stockage de données.  
+Jours Fériés n'utilise aucun service tiers pour l'analyse, la publicité ou le stockage de données.  
   
 ## Contact par e-mail  
   
@@ -39,4 +39,4 @@ Ces informations servent uniquement à répondre à votre demande. **Elles ne so
   
 Si vous avez des questions sur cette politique, n'hésitez pas à consulter la section [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays est un projet personnel. Tous les messages sont lus et appréciés.**  
+**Jours Fériés est un projet personnel. Tous les messages sont lus et appréciés.**  

--- a/docs/fr/support.md
+++ b/docs/fr/support.md
@@ -1,43 +1,43 @@
-# Assistance pour Holidays  
+# Assistance pour Jours Fériés  
   
-Merci d'utiliser Holidays. Si vous trouvez des bugs, avez des questions ou souhaitez proposer des améliorations, contactez-moi ou participez à ce dépôt.  
+Merci d'utiliser Jours Fériés. Si vous trouvez des bugs, avez des questions ou souhaitez proposer des améliorations, contactez-moi ou participez à ce dépôt.  
 C'est un projet personnel, tout retour ou contribution est donc très apprécié.  
   
 ## Signaler un problème  
   
 Vous pouvez ouvrir une issue dans ce dépôt en décrivant le problème et les étapes pour le reproduire. Si possible, joignez une capture d'écran.  
   
-[Ouvrir une issue](https://github.com/lucasditomase/feriados/issues/new?title=Problème%20avec%20Holidays%20App&body=Décrivez%20le%20problème%20que%20vous%20rencontrez%20ci-dessous%3A%0A%0A-%20Appareil%3A%20%0A-%20Version%20iOS%3A%20%0A-%20Version%20de%20l'application%3A%20%0A-%20Étapes%20pour%20reproduire%3A%0A%0A%28Facultatif%29%20Joignez%20une%20capture%20d'écran%20ou%20un%20enregistrement%20si%20possible.)  
+[Ouvrir une issue](https://github.com/lucasditomase/feriados/issues/new?title=Problème%20avec%20Jours%20F%C3%A9ri%C3%A9s%20App&body=Décrivez%20le%20problème%20que%20vous%20rencontrez%20ci-dessous%3A%0A%0A-%20Appareil%3A%20%0A-%20Version%20iOS%3A%20%0A-%20Version%20de%20l'application%3A%20%0A-%20Étapes%20pour%20reproduire%3A%0A%0A%28Facultatif%29%20Joignez%20une%20capture%20d'écran%20ou%20un%20enregistrement%20si%20possible.)  
   
 Vous pouvez également me contacter par e-mail si vous préférez ne pas utiliser GitHub. Dans l'application, dans la section "Plus d'infos", il y a une option pour envoyer un e-mail avec tous les détails techniques inclus (modèle d'appareil, langue, version d'iOS, etc.).  
   
 ## Foire aux questions  
   
 **Puis-je ajouter les fériés à mon calendrier ?**  
-Oui, avec Holidays Pro vous pouvez ajouter n'importe quel férié directement à votre calendrier personnel.  
+Oui, avec Jours Fériés Pro vous pouvez ajouter n'importe quel férié directement à votre calendrier personnel.  
   
 **Puis-je programmer des rappels pour les fériés ?**  
-Oui, Holidays Pro vous permet de créer des rappels pour être notifié avant chaque férié.  
+Oui, Jours Fériés Pro vous permet de créer des rappels pour être notifié avant chaque férié.  
   
 **Que comprend la version gratuite ?**  
 Elle comprend le calendrier complet des fériés nationaux, touristiques et religieux, un agenda hebdomadaire et des filtres de base par type de férié.  
   
-**Quelles fonctionnalités supplémentaires offre Holidays Pro ?**  
+**Quelles fonctionnalités supplémentaires offre Jours Fériés Pro ?**  
 Elle offre des rappels, l'ajout de fériés au calendrier, des statistiques comparatives, des filtres par communauté, une recherche avancée et des vues améliorées du calendrier.  
   
 **Pourquoi y a-t-il des fériés religieux ?**  
-Holidays permet de filtrer par communauté (musulmane, juive, arménienne) afin que chaque utilisateur puisse voir les dates pertinentes selon ses préférences.  
+Jours Fériés permet de filtrer par communauté (musulmane, juive, arménienne) afin que chaque utilisateur puisse voir les dates pertinentes selon ses préférences.  
   
 **Les fériés sont-ils toujours à jour ?**  
 Les informations proviennent de sources publiques officielles et sont mises à jour régulièrement. Cependant, des changements imprévus peuvent survenir en raison de décisions gouvernementales ou d'erreurs humaines.  
   
 **L'application collecte-t-elle des données personnelles ?**  
-Non. Holidays ne stocke ni ne transmet aucune donnée utilisateur. Tout se passe localement sur votre appareil.  
+Non. Jours Fériés ne stocke ni ne transmet aucune donnée utilisateur. Tout se passe localement sur votre appareil.  
   
 **Que se passe-t-il si j'envoie un e-mail depuis l'application ?**  
 Vous partagerez votre adresse e-mail et le nom configuré dans votre compte. Ces informations sont utilisées uniquement pour répondre à votre message. **Elles ne sont jamais partagées ni vendues.**  
   
-**Comment fonctionne Holidays Pro ?**  
+**Comment fonctionne Jours Fériés Pro ?**  
 Il s'agit d'un abonnement facultatif que vous pouvez activer ou annuler depuis votre compte App Store. Il inclut des fonctionnalités avancées telles que des rappels, l'intégration au calendrier, des statistiques, des filtres par communauté, une recherche avancée, la comparaison des fériés et des vues du calendrier améliorées.  
   
 **Y a-t-il une période d'essai gratuite ?**  
@@ -50,5 +50,5 @@ Oui, via le partage familial Apple, sans frais supplémentaires, à condition qu
   
 Si vous souhaitez me contacter directement ou laisser un commentaire public, rejoignez la section [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Votre message ne sera pas perdu.** Holidays est un projet personnel, je lis donc personnellement tous les messages et suggestions.  
+**Votre message ne sera pas perdu.** Jours Fériés est un projet personnel, je lis donc personnellement tous les messages et suggestions.  
 De plus, votre adresse e-mail n'est utilisée que pour répondre à votre demande.  

--- a/docs/fr/terms-and-conditions.md
+++ b/docs/fr/terms-and-conditions.md
@@ -4,11 +4,11 @@
   
 *En téléchargeant ou en utilisant l'application, vous acceptez ces conditions.*  
   
-Ces conditions régissent l'utilisation de **Holidays**, une application iOS développée par **Lucas Di Tomase** pour afficher les jours fériés officiels d'Argentine. Vous disposez d'une **licence limitée, non exclusive, non transmissible et révocable** pour utiliser l'application à des fins personnelles.  
+Ces conditions régissent l'utilisation de **Jours Fériés**, une application iOS développée par **Lucas Di Tomase** pour afficher les jours fériés officiels d'Argentine. Vous disposez d'une **licence limitée, non exclusive, non transmissible et révocable** pour utiliser l'application à des fins personnelles.  
   
 ## Utilisation de l'application  
   
-Holidays est destinée à un **usage personnel et non commercial** uniquement. Elle ne peut pas être utilisée à des fins lucratives, revendue ou intégrée à un autre produit ou service.  
+Jours Fériés est destinée à un **usage personnel et non commercial** uniquement. Elle ne peut pas être utilisée à des fins lucratives, revendue ou intégrée à un autre produit ou service.  
   
 ## Contenu  
   
@@ -16,14 +16,14 @@ Les informations affichées dans l'application proviennent de sources publiques 
   
 ## Fonctionnalités et abonnements  
   
-Holidays offre gratuitement des fonctionnalités de base, notamment :  
+Jours Fériés offre gratuitement des fonctionnalités de base, notamment :  
   
 • Affichage des jours fériés nationaux, touristiques et religieux  
 • Filtres par type de férié  
 • Agenda hebdomadaire des fériés à venir  
 • Recherche par nom ou motif  
   
-Des fonctionnalités avancées sont disponibles via un abonnement appelé **Holidays Pro**, qui inclut :  
+Des fonctionnalités avancées sont disponibles via un abonnement appelé **Jours Fériés Pro**, qui inclut :  
   
 • Filtres par communauté spécifique (musulmane, juive, arménienne)  
 • Ajout des fériés à votre calendrier personnel  
@@ -35,7 +35,7 @@ Des fonctionnalités avancées sont disponibles via un abonnement appelé **Holi
   
 ## Abonnements et période d'essai  
   
-• Les abonnements à Holidays Pro **se renouvellent automatiquement** sauf annulation **au moins 24 heures avant** la fin de la période en cours  
+• Les abonnements à Jours Fériés Pro **se renouvellent automatiquement** sauf annulation **au moins 24 heures avant** la fin de la période en cours  
 • Le paiement est effectué via l'identifiant Apple utilisé pour l'achat  
 • Si une **période d'essai gratuite** est proposée, l'abonnement commencera automatiquement à la fin de celle-ci sauf annulation au moins 24 heures à l'avance  
 • La gestion et l'annulation de l'abonnement doivent être effectuées dans les réglages de votre compte App Store  
@@ -55,7 +55,7 @@ Toute suggestion, tout commentaire ou idée que vous soumettez pourra être util
   
 ## Propriété intellectuelle  
   
-Tout le contenu, les interfaces, les graphismes, le code source et les fonctionnalités de Holidays sont la propriété exclusive du développeur, sauf indication contraire. Aucun droit de propriété intellectuelle n'est accordé à l'utilisateur par l'usage de l'application.  
+Tout le contenu, les interfaces, les graphismes, le code source et les fonctionnalités de Jours Fériés sont la propriété exclusive du développeur, sauf indication contraire. Aucun droit de propriété intellectuelle n'est accordé à l'utilisateur par l'usage de l'application.  
   
 ## Restrictions techniques  
   
@@ -79,10 +79,10 @@ L'utilisation de l'application se fait à vos risques et périls. **Ni le dével
   
 ## Confidentialité  
   
-Holidays ne collecte pas de données personnelles et n'utilise pas de services tiers pour l'analyse ou la publicité. Pour plus de détails, veuillez consulter la [Politique de confidentialité](https://lucasditomase.github.io/feriados/fr/privacy-policy).  
+Jours Fériés ne collecte pas de données personnelles et n'utilise pas de services tiers pour l'analyse ou la publicité. Pour plus de détails, veuillez consulter la [Politique de confidentialité](https://lucasditomase.github.io/feriados/fr/privacy-policy).  
   
 ## Contact  
   
 Pour toute question, assistance ou suggestion, rendez-vous dans la section [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays est un projet personnel. Si vous me contactez, je lirai personnellement votre message.**  
+**Jours Fériés est un projet personnel. Si vous me contactez, je lirai personnellement votre message.**  

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -1,11 +1,11 @@
-[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+[![Festività App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
   
-# Holidays  
+# Festività  
   
-Holidays: il tuo tempo libero, ben sfruttato.  
+Festività: il tuo tempo libero, ben sfruttato.  
   
 Il modo più semplice, chiaro e potente per consultare le festività in Argentina.  
-Con un design moderno e funzioni pensate per la vita di tutti i giorni, Holidays ti aiuta a programmare gite, vacanze o semplicemente a goderti di più i fine settimana.  
+Con un design moderno e funzioni pensate per la vita di tutti i giorni, Festività ti aiuta a programmare gite, vacanze o semplicemente a goderti di più i fine settimana.  
   
 Controlla in pochi secondi quando è la prossima festività, esplora il calendario completo e filtra i giorni non lavorativi in base ai tuoi interessi, credenze o stile di vita.  
   
@@ -21,7 +21,7 @@ Ideale per studenti, lavoratori, famiglie e chiunque voglia sfruttare meglio i p
 • Agenda settimanale per vedere le festività vicine  
 • Interfaccia moderna e chiara adattabile a tutti i dispositivi  
   
-## Funzionalità avanzate con Holidays Pro  
+## Funzionalità avanzate con Festività Pro  
   
 • Aggiungi le festività al tuo calendario personale  
 • Ricevi notifiche prima di ogni festività  
@@ -32,7 +32,7 @@ Ideale per studenti, lavoratori, famiglie e chiunque voglia sfruttare meglio i p
 • Ricerca avanzata per giorno della settimana o mese  
 • Vista mensile e settimanale dettagliata del calendario  
   
-**Holidays Pro** include una prova gratuita. Annullala almeno 24 ore prima della fine se non vuoi che ti venga addebitato nulla.  
+**Festività Pro** include una prova gratuita. Annullala almeno 24 ore prima della fine se non vuoi che ti venga addebitato nulla.  
   
 ## Informativa sulla privacy e termini  
   
@@ -45,7 +45,7 @@ Se hai domande, suggerimenti o vuoi partecipare alla community, sentiti libero d
   
 ---  
   
-*Holidays è un progetto personale. Grazie per sostenere gli sviluppatori indipendenti.*  
+*Festività è un progetto personale. Grazie per sostenere gli sviluppatori indipendenti.*  
   
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  

--- a/docs/it/privacy-policy.md
+++ b/docs/it/privacy-policy.md
@@ -2,20 +2,20 @@
   
 **Ultimo aggiornamento: maggio 2025**  
   
-**Holidays è un'app che rispetta la tua privacy:** *non raccoglie, conserva né condivide informazioni personali degli utenti.*  
+**Festività è un'app che rispetta la tua privacy:** *non raccoglie, conserva né condivide informazioni personali degli utenti.*  
   
 ## Raccolta dei dati  
   
 L'app non richiede permessi non necessari né accede a dati sensibili.  
 Tutte le informazioni mostrate (festività nazionali, turistiche e religiose) sono pubbliche e memorizzate localmente sul dispositivo dell'utente.  
   
-Le funzioni aggiuntive di Holidays Pro, come le statistiche e i confronti delle festività, vengono generate e processate localmente sul tuo dispositivo. Nessuna informazione viene inviata o salvata su server esterni.  
+Le funzioni aggiuntive di Festività Pro, come le statistiche e i confronti delle festività, vengono generate e processate localmente sul tuo dispositivo. Nessuna informazione viene inviata o salvata su server esterni.  
   
 ## Acquisti in-app e prova gratuita  
   
-L'app offre abbonamenti tramite l'App Store. Tutti i pagamenti, le prove gratuite e la gestione degli abbonamenti sono gestiti esclusivamente da Apple. **Holidays non accede in alcun momento a dati personali, finanziari o di fatturazione.**  
+L'app offre abbonamenti tramite l'App Store. Tutti i pagamenti, le prove gratuite e la gestione degli abbonamenti sono gestiti esclusivamente da Apple. **Festività non accede in alcun momento a dati personali, finanziari o di fatturazione.**  
   
-Se è disponibile un periodo di prova, potrai utilizzare Holidays Pro gratuitamente durante tale periodo. Verrai addebitato automaticamente alla fine della prova **a meno che tu non annulli l'abbonamento almeno 24 ore prima** tramite il tuo account App Store.  
+Se è disponibile un periodo di prova, potrai utilizzare Festività Pro gratuitamente durante tale periodo. Verrai addebitato automaticamente alla fine della prova **a meno che tu non annulli l'abbonamento almeno 24 ore prima** tramite il tuo account App Store.  
   
 ## Permessi facoltativi  
   
@@ -27,7 +27,7 @@ Se decidi di aggiungere una festività al tuo calendario, verrà salvato un sing
   
 ## Terze parti  
   
-Holidays non utilizza servizi di terze parti per analisi, pubblicità o archiviazione dei dati.  
+Festività non utilizza servizi di terze parti per analisi, pubblicità o archiviazione dei dati.  
   
 ## Contatto email  
   
@@ -39,4 +39,4 @@ Queste informazioni vengono usate esclusivamente per rispondere alla tua richies
   
 Se hai domande su questa politica, sentiti libero di scrivere nella sezione [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays è un progetto personale. Tutte le richieste vengono lette e apprezzate.**  
+**Festività è un progetto personale. Tutte le richieste vengono lette e apprezzate.**  

--- a/docs/it/support.md
+++ b/docs/it/support.md
@@ -1,43 +1,43 @@
-# Supporto per Holidays  
+# Supporto per Festività  
   
-Grazie per utilizzare Holidays. Se trovi bug, hai domande o vuoi suggerire miglioramenti, contattami pure o partecipa a questo repository.  
+Grazie per utilizzare Festività. Se trovi bug, hai domande o vuoi suggerire miglioramenti, contattami pure o partecipa a questo repository.  
 Si tratta di un progetto personale, quindi ogni feedback o contributo è molto apprezzato.  
   
 ## Segnala un problema  
   
 Puoi aprire un'issue in questo repository descrivendo il problema e i passaggi per riprodurlo. Se possibile, allega uno screenshot.  
   
-[Apri un'issue](https://github.com/lucasditomase/feriados/issues/new?title=Problema%20con%20Holidays%20App&body=Descrivi%20il%20problema%20che%20stai%20riscontrando%20qui%3A%0A%0A-%20Dispositivo%3A%20%0A-%20Versione%20iOS%3A%20%0A-%20Versione%20app%3A%20%0A-%20Passaggi%20per%20riprodurre%3A%0A%0A(Opzionale)%20Allega%20uno%20screenshot%20o%20una%20registrazione%20se%20puoi.)  
+[Apri un'issue](https://github.com/lucasditomase/feriados/issues/new?title=Problema%20con%20Festività%20App&body=Descrivi%20il%20problema%20che%20stai%20riscontrando%20qui%3A%0A%0A-%20Dispositivo%3A%20%0A-%20Versione%20iOS%3A%20%0A-%20Versione%20app%3A%20%0A-%20Passaggi%20per%20riprodurre%3A%0A%0A(Opzionale)%20Allega%20uno%20screenshot%20o%20una%20registrazione%20se%20puoi.)  
   
 Puoi anche contattarmi via email se preferisci non usare GitHub. Nell'app, nella sezione "Maggiori informazioni", c'è un'opzione per inviare una email con tutti i dettagli tecnici inclusi (modello del dispositivo, lingua, versione di iOS, ecc.).  
   
 ## Domande frequenti  
   
 **Posso aggiungere le festività al calendario?**  
-Sì, con Holidays Pro puoi aggiungere qualsiasi festività direttamente al tuo calendario personale.  
+Sì, con Festività Pro puoi aggiungere qualsiasi festività direttamente al tuo calendario personale.  
   
 **Posso impostare promemoria per le festività?**  
-Sì, Holidays Pro ti permette di creare promemoria per essere avvisato prima di ogni festività.  
+Sì, Festività Pro ti permette di creare promemoria per essere avvisato prima di ogni festività.  
   
 **Cosa include la versione gratuita?**  
 Include il calendario completo di festività nazionali, turistiche e religiose, un'agenda settimanale e filtri base per tipo di festività.  
   
-**Quali funzioni extra offre Holidays Pro?**  
+**Quali funzioni extra offre Festività Pro?**  
 Include promemoria, aggiunta delle festività al calendario, statistiche comparative, filtri per comunità, ricerca avanzata e viste del calendario migliorate.  
   
 **Perché ci sono festività religiose?**  
-Holidays permette di filtrare per comunità (musulmana, ebraica, armena) così ogni utente può visualizzare le date rilevanti in base alle proprie preferenze.  
+Festività permette di filtrare per comunità (musulmana, ebraica, armena) così ogni utente può visualizzare le date rilevanti in base alle proprie preferenze.  
   
 **Le festività sono sempre aggiornate?**  
 Le informazioni provengono da fonti pubbliche ufficiali e vengono aggiornate regolarmente. Tuttavia potrebbero esserci variazioni impreviste dovute a decisioni governative o errori umani.  
   
 **L'app raccoglie dati personali?**  
-No. Holidays non memorizza né trasmette dati degli utenti. Tutto avviene localmente sul dispositivo.  
+No. Festività non memorizza né trasmette dati degli utenti. Tutto avviene localmente sul dispositivo.  
   
 **Cosa succede se invio un'email dall'app?**  
 Condividerai il tuo indirizzo email e il nome configurato nel tuo account. Queste informazioni vengono usate solo per rispondere al tuo messaggio. **Non vengono mai condivise o vendute.**  
   
-**Come funziona Holidays Pro?**  
+**Come funziona Festività Pro?**  
 È un abbonamento opzionale che puoi attivare o cancellare dal tuo account App Store. Include funzionalità avanzate come promemoria, integrazione con il calendario, statistiche, filtri per comunità, ricerca avanzata, confronti tra festività e viste del calendario migliorate.  
   
 **Esiste una prova gratuita?**  
@@ -50,5 +50,5 @@ Sì, tramite Condivisione familiare di Apple, senza costi aggiuntivi, a patto ch
   
 Se vuoi metterti in contatto direttamente o lasciare un commento pubblico, puoi partecipare alla sezione [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Il tuo messaggio non andrà perso.** Holidays è un progetto personale, quindi leggo personalmente tutti i messaggi e i suggerimenti.  
+**Il tuo messaggio non andrà perso.** Festività è un progetto personale, quindi leggo personalmente tutti i messaggi e i suggerimenti.  
 Inoltre, il tuo indirizzo email viene usato solo per rispondere alla tua richiesta.  

--- a/docs/it/terms-and-conditions.md
+++ b/docs/it/terms-and-conditions.md
@@ -4,11 +4,11 @@
   
 *Scaricando o utilizzando l'app accetti questi termini.*  
   
-Questi termini regolano l'uso di **Holidays**, un'applicazione iOS sviluppata da **Lucas Di Tomase** per mostrare i giorni festivi ufficiali in Argentina. Ti viene concessa una **licenza limitata, non esclusiva, non trasferibile e revocabile** per utilizzare l'app a fini personali.  
+Questi termini regolano l'uso di **Festività**, un'applicazione iOS sviluppata da **Lucas Di Tomase** per mostrare i giorni festivi ufficiali in Argentina. Ti viene concessa una **licenza limitata, non esclusiva, non trasferibile e revocabile** per utilizzare l'app a fini personali.  
   
 ## Uso dell'app  
   
-Holidays è destinata esclusivamente a un **uso personale e non commerciale**. Non può essere utilizzata a scopo di lucro, rivenduta o incorporata in altri prodotti o servizi.  
+Festività è destinata esclusivamente a un **uso personale e non commerciale**. Non può essere utilizzata a scopo di lucro, rivenduta o incorporata in altri prodotti o servizi.  
   
 ## Contenuto  
   
@@ -16,14 +16,14 @@ Le informazioni visualizzate nell'app provengono da fonti pubbliche e possono su
   
 ## Funzioni e abbonamenti  
   
-Holidays offre gratuitamente funzioni di base, tra cui:  
+Festività offre gratuitamente funzioni di base, tra cui:  
   
 • Visualizzazione dei giorni festivi nazionali, turistici e religiosi  
 • Filtri per tipo di festività  
 • Agenda settimanale delle festività imminenti  
 • Ricerca per nome o motivo  
   
-Funzioni avanzate sono disponibili tramite un abbonamento chiamato **Holidays Pro**, che include:  
+Funzioni avanzate sono disponibili tramite un abbonamento chiamato **Festività Pro**, che include:  
   
 • Filtri per comunità specifiche (musulmana, ebraica, armena)  
 • Aggiunta dei festivi al tuo calendario personale  
@@ -35,7 +35,7 @@ Funzioni avanzate sono disponibili tramite un abbonamento chiamato **Holidays Pr
   
 ## Abbonamenti e prova gratuita  
   
-• Gli abbonamenti a Holidays Pro **si rinnovano automaticamente** a meno che non vengano cancellati **almeno 24 ore prima** della fine del periodo in corso  
+• Gli abbonamenti a Festività Pro **si rinnovano automaticamente** a meno che non vengano cancellati **almeno 24 ore prima** della fine del periodo in corso  
 • Il pagamento viene addebitato sull'ID Apple utilizzato per l'acquisto  
 • Se è prevista una **prova gratuita**, l'abbonamento inizierà automaticamente al termine della prova a meno che non venga cancellato con almeno 24 ore di anticipo  
 • La gestione e la cancellazione dell'abbonamento devono essere effettuate dalle impostazioni del tuo account App Store  
@@ -55,7 +55,7 @@ Qualsiasi suggerimento, commento o idea inviati potranno essere utilizzati per m
   
 ## Proprietà intellettuale  
   
-Tutti i contenuti, le interfacce, la grafica, il codice sorgente e le funzionalità di Holidays sono di esclusiva proprietà dello sviluppatore, salvo diversa indicazione. Nessun diritto di proprietà intellettuale viene concesso all'utente attraverso l'uso dell'app.  
+Tutti i contenuti, le interfacce, la grafica, il codice sorgente e le funzionalità di Festività sono di esclusiva proprietà dello sviluppatore, salvo diversa indicazione. Nessun diritto di proprietà intellettuale viene concesso all'utente attraverso l'uso dell'app.  
   
 ## Restrizioni tecniche  
   
@@ -79,10 +79,10 @@ L'uso dell'app avviene a tuo rischio. **Né lo sviluppatore (Lucas Di Tomase) n�
   
 ## Privacy  
   
-Holidays non raccoglie dati personali né utilizza servizi di terze parti per analisi o pubblicità. Per maggiori dettagli consulta l'[Informativa sulla privacy](https://lucasditomase.github.io/feriados/it/privacy-policy).  
+Festività non raccoglie dati personali né utilizza servizi di terze parti per analisi o pubblicità. Per maggiori dettagli consulta l'[Informativa sulla privacy](https://lucasditomase.github.io/feriados/it/privacy-policy).  
   
 ## Contatto  
   
 Per domande, supporto o suggerimenti puoi visitare la sezione [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays è un progetto personale. Se ci contatti, leggerò personalmente il tuo messaggio.**  
+**Festività è un progetto personale. Se ci contatti, leggerò personalmente il tuo messaggio.**  

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -1,11 +1,11 @@
-[![Holidays App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+[![Feriados App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
   
-# Holidays  
+# Feriados  
   
-Holidays: seu tempo livre, bem aproveitado.  
+Feriados: seu tempo livre, bem aproveitado.  
   
 A forma mais simples, clara e poderosa de consultar os feriados na Argentina.  
-Com design moderno e funcionalidades pensadas para o dia a dia, Holidays ajuda você a planejar viagens, férias ou simplesmente aproveitar mais seus fins de semana.  
+Com design moderno e funcionalidades pensadas para o dia a dia, Feriados ajuda você a planejar viagens, férias ou simplesmente aproveitar mais seus fins de semana.  
   
 Consulte em segundos quando é o próximo feriado, explore o calendário completo e filtre os dias não úteis conforme seus interesses, crenças ou estilo de vida.  
   
@@ -21,7 +21,7 @@ Ideal para estudantes, trabalhadores, famílias e qualquer pessoa que queira apr
 • Agenda semanal para ver os feriados próximos  
 • Interface moderna e clara adaptável a todos os dispositivos  
   
-## Recursos avançados com Holidays Pro  
+## Recursos avançados com Feriados Pro  
   
 • Adicione feriados ao seu calendário pessoal  
 • Receba notificações antes de cada feriado  
@@ -32,7 +32,7 @@ Ideal para estudantes, trabalhadores, famílias e qualquer pessoa que queira apr
 • Busca avançada por dia da semana ou mês  
 • Vista mensal e semanal detalhada do calendário  
   
-**Holidays Pro** inclui um período de teste gratuito. Cancele pelo menos 24 horas antes do fim se não quiser ser cobrado.  
+**Feriados Pro** inclui um período de teste gratuito. Cancele pelo menos 24 horas antes do fim se não quiser ser cobrado.  
   
 ## Política de privacidade e termos  
   
@@ -45,7 +45,7 @@ Se você tiver dúvidas, sugestões ou quiser participar da comunidade, fique à
   
 ---  
   
-*Holidays é um projeto pessoal. Obrigado por apoiar desenvolvedores independentes.*  
+*Feriados é um projeto pessoal. Obrigado por apoiar desenvolvedores independentes.*  
   
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  

--- a/docs/pt/privacy-policy.md
+++ b/docs/pt/privacy-policy.md
@@ -2,20 +2,20 @@
   
 **Atualização mais recente: maio de 2025**  
   
-**Holidays é um aplicativo que respeita sua privacidade:** *não coleta, armazena nem compartilha informações pessoais dos usuários.*  
+**Feriados é um aplicativo que respeita sua privacidade:** *não coleta, armazena nem compartilha informações pessoais dos usuários.*  
   
 ## Coleta de dados  
   
 O aplicativo não solicita permissões desnecessárias nem acessa dados sensíveis.  
 Todas as informações exibidas (feriados nacionais, turísticos e religiosos) são públicas e armazenadas localmente no dispositivo do usuário.  
   
-Os recursos adicionais do Holidays Pro, como estatísticas e comparações de feriados, são gerados e processados localmente no seu dispositivo. Nenhuma informação é enviada ou armazenada em servidores externos.  
+Os recursos adicionais do Feriados Pro, como estatísticas e comparações de feriados, são gerados e processados localmente no seu dispositivo. Nenhuma informação é enviada ou armazenada em servidores externos.  
   
 ## Compras dentro do app e período de teste gratuito  
   
-O aplicativo oferece assinaturas pela App Store. Todo o processamento de pagamento, testes gratuitos e gestão da assinatura são feitos exclusivamente pela Apple. **Holidays não acessa dados pessoais, financeiros ou de faturamento em nenhum momento.**  
+O aplicativo oferece assinaturas pela App Store. Todo o processamento de pagamento, testes gratuitos e gestão da assinatura são feitos exclusivamente pela Apple. **Feriados não acessa dados pessoais, financeiros ou de faturamento em nenhum momento.**  
   
-Se houver um período de teste disponível, você poderá usar o Holidays Pro gratuitamente durante esse tempo. A cobrança será feita automaticamente ao final do período, **a menos que você cancele a assinatura com pelo menos 24 horas de antecedência** na sua conta da App Store.  
+Se houver um período de teste disponível, você poderá usar o Feriados Pro gratuitamente durante esse tempo. A cobrança será feita automaticamente ao final do período, **a menos que você cancele a assinatura com pelo menos 24 horas de antecedência** na sua conta da App Store.  
   
 ## Permissões opcionais  
   
@@ -27,7 +27,7 @@ Se você decidir adicionar um feriado ao seu calendário, será salvo um único 
   
 ## Terceiros  
   
-Holidays não utiliza serviços de terceiros para análise, publicidade ou armazenamento de dados.  
+Feriados não utiliza serviços de terceiros para análise, publicidade ou armazenamento de dados.  
   
 ## Contato por email  
   
@@ -39,4 +39,4 @@ Essas informações são usadas apenas para responder à sua solicitação. **Nu
   
 Se tiver dúvidas sobre esta política, sinta-se à vontade para escrever na seção [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays é um projeto pessoal. Todas as mensagens são lidas e valorizadas.**  
+**Feriados é um projeto pessoal. Todas as mensagens são lidas e valorizadas.**  

--- a/docs/pt/support.md
+++ b/docs/pt/support.md
@@ -1,43 +1,43 @@
-# Suporte ao Holidays  
+# Suporte ao Feriados  
   
-Obrigado por usar o Holidays. Se encontrar bugs, tiver dúvidas ou quiser sugerir melhorias, entre em contato comigo ou participe deste repositório.  
+Obrigado por usar o Feriados. Se encontrar bugs, tiver dúvidas ou quiser sugerir melhorias, entre em contato comigo ou participe deste repositório.  
 Este é um projeto pessoal, portanto qualquer feedback ou contribuição é muito bem-vindo.  
   
 ## Relatar um problema  
   
 Você pode abrir uma issue neste repositório descrevendo o problema e os passos para reproduzi-lo. Se possível, inclua uma captura de tela.  
   
-[Abrir uma issue](https://github.com/lucasditomase/feriados/issues/new?title=Problema%20com%20Holidays%20App&body=Descreva%20o%20problema%20que%20você%20está%20enfrentando%20abaixo%3A%0A%0A-%20Dispositivo%3A%20%0A-%20Versão%20do%20iOS%3A%20%0A-%20Versão%20do%20app%3A%20%0A-%20Passos%20para%20reproduzir%3A%0A%0A(Opcional)%20Anexe%20uma%20captura%20de%20tela%20ou%20gravação%20se%20puder.)  
+[Abrir uma issue](https://github.com/lucasditomase/feriados/issues/new?title=Problema%20com%20Feriados%20App&body=Descreva%20o%20problema%20que%20você%20está%20enfrentando%20abaixo%3A%0A%0A-%20Dispositivo%3A%20%0A-%20Versão%20do%20iOS%3A%20%0A-%20Versão%20do%20app%3A%20%0A-%20Passos%20para%20reproduzir%3A%0A%0A(Opcional)%20Anexe%20uma%20captura%20de%20tela%20ou%20gravação%20se%20puder.)  
   
 Você também pode me contatar por email se preferir não usar o GitHub. No app, na seção "Mais informações", há uma opção para enviar um email com todos os detalhes técnicos já incluídos (modelo do dispositivo, idioma, versão do iOS, etc.).  
   
 ## Perguntas frequentes  
   
 **Posso adicionar os feriados ao meu calendário?**  
-Sim, com o Holidays Pro você pode adicionar qualquer feriado diretamente ao seu calendário pessoal.  
+Sim, com o Feriados Pro você pode adicionar qualquer feriado diretamente ao seu calendário pessoal.  
   
 **Posso configurar lembretes para os feriados?**  
-Sim, o Holidays Pro permite criar lembretes para ser notificado antes de cada feriado.  
+Sim, o Feriados Pro permite criar lembretes para ser notificado antes de cada feriado.  
   
 **O que inclui a versão gratuita?**  
 Inclui o calendário completo de feriados nacionais, turísticos e religiosos, uma agenda semanal e filtros básicos por tipo de feriado.  
   
-**Quais recursos extras o Holidays Pro oferece?**  
+**Quais recursos extras o Feriados Pro oferece?**  
 Inclui lembretes, adição de feriados ao calendário, estatísticas comparativas, filtros por comunidade, busca avançada e visualizações aprimoradas do calendário.  
   
 **Por que existem feriados religiosos?**  
-O Holidays permite filtrar por comunidade (muçulmana, judaica, armênia) para que cada usuário veja as datas relevantes de acordo com suas preferências.  
+O Feriados permite filtrar por comunidade (muçulmana, judaica, armênia) para que cada usuário veja as datas relevantes de acordo com suas preferências.  
   
 **Os feriados estão sempre atualizados?**  
 As informações provêm de fontes públicas oficiais e são atualizadas regularmente. Entretanto, podem ocorrer mudanças inesperadas devido a decisões do governo ou erro humano.  
   
 **O aplicativo coleta dados pessoais?**  
-Não. O Holidays não armazena nem transmite dados dos usuários. Tudo acontece localmente no dispositivo.  
+Não. O Feriados não armazena nem transmite dados dos usuários. Tudo acontece localmente no dispositivo.  
   
 **O que acontece se eu enviar um email pelo app?**  
 Você compartilhará seu endereço de email e o nome configurado na sua conta. Essas informações são usadas apenas para responder à sua mensagem. **Nunca são compartilhadas ou vendidas.**  
   
-**Como funciona o Holidays Pro?**  
+**Como funciona o Feriados Pro?**  
 É uma assinatura opcional que você pode ativar ou cancelar na sua conta da App Store. Inclui recursos avançados como lembretes, integração com calendário, estatísticas, filtros por comunidade, busca avançada, comparação de feriados e visualizações aprimoradas do calendário.  
   
 **Existe período de teste gratuito?**  
@@ -50,5 +50,5 @@ Sim, através do Compartilhamento Familiar da Apple, sem custo adicional, desde 
   
 Se quiser entrar em contato diretamente ou deixar um comentário público, participe da seção [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Sua mensagem não será perdida.** O Holidays é um projeto pessoal, portanto eu leio pessoalmente todas as mensagens e sugestões.  
+**Sua mensagem não será perdida.** O Feriados é um projeto pessoal, portanto eu leio pessoalmente todas as mensagens e sugestões.  
 Além disso, seu email é usado apenas para responder à sua solicitação.  

--- a/docs/pt/terms-and-conditions.md
+++ b/docs/pt/terms-and-conditions.md
@@ -4,11 +4,11 @@
   
 *Ao baixar ou usar o aplicativo, você concorda com estes termos.*  
   
-Estes termos regem o uso do **Holidays**, um aplicativo iOS desenvolvido por **Lucas Di Tomase** para exibir os feriados oficiais da Argentina. Você recebe uma **licença limitada, não exclusiva, intransferível e revogável** para usar o aplicativo para fins pessoais.  
+Estes termos regem o uso do **Feriados**, um aplicativo iOS desenvolvido por **Lucas Di Tomase** para exibir os feriados oficiais da Argentina. Você recebe uma **licença limitada, não exclusiva, intransferível e revogável** para usar o aplicativo para fins pessoais.  
   
 ## Uso do aplicativo  
   
-O Holidays destina-se apenas ao **uso pessoal e não comercial**. Não pode ser utilizado para obter lucro, revendido ou incorporado a outro produto ou serviço.  
+O Feriados destina-se apenas ao **uso pessoal e não comercial**. Não pode ser utilizado para obter lucro, revendido ou incorporado a outro produto ou serviço.  
   
 ## Conteúdo  
   
@@ -16,14 +16,14 @@ As informações exibidas no aplicativo provêm de fontes públicas e podem sofr
   
 ## Recursos e assinaturas  
   
-O Holidays oferece recursos básicos gratuitos, incluindo:  
+O Feriados oferece recursos básicos gratuitos, incluindo:  
   
 • Exibição de feriados nacionais, turísticos e religiosos  
 • Filtros por tipo de feriado  
 • Agenda semanal dos próximos feriados  
 • Busca por nome ou motivo  
   
-Recursos avançados estão disponíveis por meio de uma assinatura chamada **Holidays Pro**, que inclui:  
+Recursos avançados estão disponíveis por meio de uma assinatura chamada **Feriados Pro**, que inclui:  
   
 • Filtros por comunidade específica (muçulmana, judaica, armênia)  
 • Adicionar feriados ao seu calendário pessoal  
@@ -35,7 +35,7 @@ Recursos avançados estão disponíveis por meio de uma assinatura chamada **Hol
   
 ## Assinaturas e período de teste  
   
-• As assinaturas do Holidays Pro **renovam-se automaticamente** a menos que sejam canceladas **pelo menos 24 horas antes** do fim do período atual  
+• As assinaturas do Feriados Pro **renovam-se automaticamente** a menos que sejam canceladas **pelo menos 24 horas antes** do fim do período atual  
 • O pagamento é cobrado do ID Apple utilizado na compra  
 • Se houver **período de teste gratuito**, a assinatura começará automaticamente ao fim do teste, a menos que seja cancelada com 24 horas de antecedência  
 • A gestão e o cancelamento da assinatura devem ser feitos nas configurações da sua conta da App Store  
@@ -55,7 +55,7 @@ Quaisquer sugestões, comentários ou ideias enviados podem ser usados para melh
   
 ## Propriedade intelectual  
   
-Todo o conteúdo, interfaces, gráficos, código-fonte e recursos do Holidays são propriedade exclusiva do desenvolvedor, salvo indicação em contrário. Nenhum direito de propriedade intelectual é concedido ao usuário pelo uso do aplicativo.  
+Todo o conteúdo, interfaces, gráficos, código-fonte e recursos do Feriados são propriedade exclusiva do desenvolvedor, salvo indicação em contrário. Nenhum direito de propriedade intelectual é concedido ao usuário pelo uso do aplicativo.  
   
 ## Restrições técnicas  
   
@@ -79,10 +79,10 @@ O uso do aplicativo é por sua conta e risco. **Nem o desenvolvedor (Lucas Di To
   
 ## Privacidade  
   
-Holidays não coleta dados pessoais nem usa serviços de terceiros para análise ou publicidade. Para mais detalhes, consulte a [Política de privacidade](https://lucasditomase.github.io/feriados/pt/privacy-policy).  
+Feriados não coleta dados pessoais nem usa serviços de terceiros para análise ou publicidade. Para mais detalhes, consulte a [Política de privacidade](https://lucasditomase.github.io/feriados/pt/privacy-policy).  
   
 ## Contato  
   
 Para perguntas, suporte ou sugestões, visite a seção [Discussions](https://github.com/lucasditomase/feriados/discussions).  
   
-**Holidays é um projeto pessoal. Se você entrar em contato, lerei pessoalmente sua mensagem.**  
+**Feriados é um projeto pessoal. Se você entrar em contato, lerei pessoalmente sua mensagem.**  


### PR DESCRIPTION
## Summary
- localize app and subscription names in docs for German, French, Italian and Portuguese

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861934e6ce8832a9692320f7bd261a9