### PR TITLE
Add docs for new languages without images

### DIFF
--- a/docs/ar/index.md
+++ b/docs/ar/index.md
@@ -1,0 +1,54 @@
+[![العطلات App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# العطلات  
+  
+العطلات: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, العطلات helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with العطلات Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**العطلات Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/ar/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/ar/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*العطلات is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/ar/privacy-policy.md
+++ b/docs/ar/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**العطلات is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in العطلات Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **العطلات does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use العطلات Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+العطلات does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**العطلات is a personal project. All inquiries are read and appreciated.**  

--- a/docs/ar/support.md
+++ b/docs/ar/support.md
@@ -1,0 +1,54 @@
+# Support for العطلات  
+  
+Thank you for using العطلات. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20العطلات%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with العطلات Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, العطلات Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does العطلات Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+العطلات allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. العطلات does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does العطلات Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** العطلات is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/ar/terms-and-conditions.md
+++ b/docs/ar/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **العطلات**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+العطلات is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+العطلات offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **العطلات Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to العطلات Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of العطلات are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+العطلات does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/ar/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**العطلات is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/hi/index.md
+++ b/docs/hi/index.md
@@ -1,0 +1,54 @@
+[![छुट्टियाँ App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# छुट्टियाँ  
+  
+छुट्टियाँ: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, छुट्टियाँ helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with छुट्टियाँ Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**छुट्टियाँ Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/hi/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/hi/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*छुट्टियाँ is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/hi/privacy-policy.md
+++ b/docs/hi/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**छुट्टियाँ is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in छुट्टियाँ Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **छुट्टियाँ does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use छुट्टियाँ Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+छुट्टियाँ does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**छुट्टियाँ is a personal project. All inquiries are read and appreciated.**  

--- a/docs/hi/support.md
+++ b/docs/hi/support.md
@@ -1,0 +1,54 @@
+# Support for छुट्टियाँ  
+  
+Thank you for using छुट्टियाँ. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20छुट्टियाँ%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with छुट्टियाँ Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, छुट्टियाँ Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does छुट्टियाँ Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+छुट्टियाँ allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. छुट्टियाँ does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does छुट्टियाँ Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** छुट्टियाँ is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/hi/terms-and-conditions.md
+++ b/docs/hi/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **छुट्टियाँ**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+छुट्टियाँ is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+छुट्टियाँ offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **छुट्टियाँ Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to छुट्टियाँ Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of छुट्टियाँ are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+छुट्टियाँ does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/hi/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**छुट्टियाँ is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/id/index.md
+++ b/docs/id/index.md
@@ -1,0 +1,54 @@
+[![Libur App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# Libur  
+  
+Libur: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, Libur helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with Libur Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**Libur Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/id/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/id/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*Libur is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/id/privacy-policy.md
+++ b/docs/id/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**Libur is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in Libur Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **Libur does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use Libur Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+Libur does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Libur is a personal project. All inquiries are read and appreciated.**  

--- a/docs/id/support.md
+++ b/docs/id/support.md
@@ -1,0 +1,54 @@
+# Support for Libur  
+  
+Thank you for using Libur. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20Libur%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with Libur Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, Libur Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does Libur Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+Libur allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. Libur does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does Libur Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** Libur is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/id/terms-and-conditions.md
+++ b/docs/id/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **Libur**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+Libur is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+Libur offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **Libur Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to Libur Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of Libur are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+Libur does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/id/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Libur is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,0 +1,54 @@
+[![祝日 App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# 祝日  
+  
+祝日: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, 祝日 helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with 祝日 Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**祝日 Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/ja/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/ja/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*祝日 is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/ja/privacy-policy.md
+++ b/docs/ja/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**祝日 is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in 祝日 Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **祝日 does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use 祝日 Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+祝日 does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**祝日 is a personal project. All inquiries are read and appreciated.**  

--- a/docs/ja/support.md
+++ b/docs/ja/support.md
@@ -1,0 +1,54 @@
+# Support for 祝日  
+  
+Thank you for using 祝日. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20祝日%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with 祝日 Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, 祝日 Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does 祝日 Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+祝日 allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. 祝日 does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does 祝日 Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** 祝日 is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/ja/terms-and-conditions.md
+++ b/docs/ja/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **祝日**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+祝日 is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+祝日 offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **祝日 Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to 祝日 Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of 祝日 are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+祝日 does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/ja/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**祝日 is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -1,0 +1,54 @@
+[![공휴일 App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# 공휴일  
+  
+공휴일: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, 공휴일 helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with 공휴일 Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**공휴일 Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/ko/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/ko/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*공휴일 is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/ko/privacy-policy.md
+++ b/docs/ko/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**공휴일 is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in 공휴일 Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **공휴일 does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use 공휴일 Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+공휴일 does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**공휴일 is a personal project. All inquiries are read and appreciated.**  

--- a/docs/ko/support.md
+++ b/docs/ko/support.md
@@ -1,0 +1,54 @@
+# Support for 공휴일  
+  
+Thank you for using 공휴일. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20공휴일%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with 공휴일 Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, 공휴일 Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does 공휴일 Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+공휴일 allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. 공휴일 does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does 공휴일 Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** 공휴일 is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/ko/terms-and-conditions.md
+++ b/docs/ko/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **공휴일**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+공휴일 is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+공휴일 offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **공휴일 Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to 공휴일 Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of 공휴일 are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+공휴일 does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/ko/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**공휴일 is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/nl/index.md
+++ b/docs/nl/index.md
@@ -1,0 +1,54 @@
+[![Feestdagen App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# Feestdagen  
+  
+Feestdagen: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, Feestdagen helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with Feestdagen Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**Feestdagen Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/nl/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/nl/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*Feestdagen is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/nl/privacy-policy.md
+++ b/docs/nl/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**Feestdagen is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in Feestdagen Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **Feestdagen does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use Feestdagen Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+Feestdagen does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Feestdagen is a personal project. All inquiries are read and appreciated.**  

--- a/docs/nl/support.md
+++ b/docs/nl/support.md
@@ -1,0 +1,54 @@
+# Support for Feestdagen  
+  
+Thank you for using Feestdagen. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20Feestdagen%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with Feestdagen Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, Feestdagen Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does Feestdagen Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+Feestdagen allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. Feestdagen does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does Feestdagen Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** Feestdagen is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/nl/terms-and-conditions.md
+++ b/docs/nl/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **Feestdagen**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+Feestdagen is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+Feestdagen offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **Feestdagen Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to Feestdagen Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of Feestdagen are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+Feestdagen does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/nl/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Feestdagen is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/pl/index.md
+++ b/docs/pl/index.md
@@ -1,0 +1,54 @@
+[![Święta App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# Święta  
+  
+Święta: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, Święta helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with Święta Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**Święta Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/pl/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/pl/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*Święta is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/pl/privacy-policy.md
+++ b/docs/pl/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**Święta is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in Święta Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **Święta does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use Święta Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+Święta does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Święta is a personal project. All inquiries are read and appreciated.**  

--- a/docs/pl/support.md
+++ b/docs/pl/support.md
@@ -1,0 +1,54 @@
+# Support for Święta  
+  
+Thank you for using Święta. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20Święta%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with Święta Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, Święta Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does Święta Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+Święta allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. Święta does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does Święta Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** Święta is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/pl/terms-and-conditions.md
+++ b/docs/pl/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **Święta**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+Święta is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+Święta offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **Święta Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to Święta Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of Święta are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+Święta does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/pl/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Święta is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/ru/index.md
+++ b/docs/ru/index.md
@@ -1,0 +1,54 @@
+[![Праздники App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# Праздники  
+  
+Праздники: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, Праздники helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with Праздники Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**Праздники Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/ru/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/ru/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*Праздники is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/ru/privacy-policy.md
+++ b/docs/ru/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**Праздники is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in Праздники Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **Праздники does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use Праздники Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+Праздники does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Праздники is a personal project. All inquiries are read and appreciated.**  

--- a/docs/ru/support.md
+++ b/docs/ru/support.md
@@ -1,0 +1,54 @@
+# Support for Праздники  
+  
+Thank you for using Праздники. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20Праздники%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with Праздники Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, Праздники Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does Праздники Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+Праздники allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. Праздники does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does Праздники Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** Праздники is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/ru/terms-and-conditions.md
+++ b/docs/ru/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **Праздники**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+Праздники is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+Праздники offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **Праздники Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to Праздники Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of Праздники are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+Праздники does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/ru/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Праздники is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/th/index.md
+++ b/docs/th/index.md
@@ -1,0 +1,54 @@
+[![วันหยุด App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# วันหยุด  
+  
+วันหยุด: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, วันหยุด helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with วันหยุด Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**วันหยุด Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/th/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/th/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*วันหยุด is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/th/privacy-policy.md
+++ b/docs/th/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**วันหยุด is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in วันหยุด Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **วันหยุด does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use วันหยุด Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+วันหยุด does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**วันหยุด is a personal project. All inquiries are read and appreciated.**  

--- a/docs/th/support.md
+++ b/docs/th/support.md
@@ -1,0 +1,54 @@
+# Support for วันหยุด  
+  
+Thank you for using วันหยุด. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20วันหยุด%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with วันหยุด Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, วันหยุด Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does วันหยุด Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+วันหยุด allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. วันหยุด does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does วันหยุด Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** วันหยุด is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/th/terms-and-conditions.md
+++ b/docs/th/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **วันหยุด**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+วันหยุด is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+วันหยุด offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **วันหยุด Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to วันหยุด Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of วันหยุด are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+วันหยุด does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/th/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**วันหยุด is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/tr/index.md
+++ b/docs/tr/index.md
@@ -1,0 +1,54 @@
+[![Tatiller App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# Tatiller  
+  
+Tatiller: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, Tatiller helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with Tatiller Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**Tatiller Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/tr/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/tr/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*Tatiller is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/tr/privacy-policy.md
+++ b/docs/tr/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**Tatiller is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in Tatiller Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **Tatiller does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use Tatiller Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+Tatiller does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Tatiller is a personal project. All inquiries are read and appreciated.**  

--- a/docs/tr/support.md
+++ b/docs/tr/support.md
@@ -1,0 +1,54 @@
+# Support for Tatiller  
+  
+Thank you for using Tatiller. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20Tatiller%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with Tatiller Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, Tatiller Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does Tatiller Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+Tatiller allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. Tatiller does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does Tatiller Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** Tatiller is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/tr/terms-and-conditions.md
+++ b/docs/tr/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **Tatiller**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+Tatiller is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+Tatiller offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **Tatiller Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to Tatiller Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of Tatiller are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+Tatiller does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/tr/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Tatiller is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/uk/index.md
+++ b/docs/uk/index.md
@@ -1,0 +1,54 @@
+[![Свята App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# Свята  
+  
+Свята: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, Свята helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with Свята Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**Свята Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/uk/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/uk/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*Свята is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/uk/privacy-policy.md
+++ b/docs/uk/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**Свята is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in Свята Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **Свята does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use Свята Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+Свята does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Свята is a personal project. All inquiries are read and appreciated.**  

--- a/docs/uk/support.md
+++ b/docs/uk/support.md
@@ -1,0 +1,54 @@
+# Support for Свята  
+  
+Thank you for using Свята. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20Свята%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with Свята Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, Свята Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does Свята Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+Свята allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. Свята does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does Свята Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** Свята is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/uk/terms-and-conditions.md
+++ b/docs/uk/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **Свята**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+Свята is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+Свята offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **Свята Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to Свята Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of Свята are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+Свята does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/uk/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Свята is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/vi/index.md
+++ b/docs/vi/index.md
@@ -1,0 +1,54 @@
+[![Ngày Nghỉ App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# Ngày Nghỉ  
+  
+Ngày Nghỉ: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, Ngày Nghỉ helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with Ngày Nghỉ Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**Ngày Nghỉ Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/vi/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/vi/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*Ngày Nghỉ is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/vi/privacy-policy.md
+++ b/docs/vi/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**Ngày Nghỉ is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in Ngày Nghỉ Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **Ngày Nghỉ does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use Ngày Nghỉ Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+Ngày Nghỉ does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Ngày Nghỉ is a personal project. All inquiries are read and appreciated.**  

--- a/docs/vi/support.md
+++ b/docs/vi/support.md
@@ -1,0 +1,54 @@
+# Support for Ngày Nghỉ  
+  
+Thank you for using Ngày Nghỉ. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20Ngày Nghỉ%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with Ngày Nghỉ Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, Ngày Nghỉ Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does Ngày Nghỉ Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+Ngày Nghỉ allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. Ngày Nghỉ does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does Ngày Nghỉ Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** Ngày Nghỉ is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/vi/terms-and-conditions.md
+++ b/docs/vi/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **Ngày Nghỉ**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+Ngày Nghỉ is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+Ngày Nghỉ offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **Ngày Nghỉ Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to Ngày Nghỉ Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of Ngày Nghỉ are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+Ngày Nghỉ does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/vi/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Ngày Nghỉ is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/zh-Hans/index.md
+++ b/docs/zh-Hans/index.md
@@ -1,0 +1,54 @@
+[![节假日 App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# 节假日  
+  
+节假日: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, 节假日 helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with 节假日 Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**节假日 Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/zh-Hans/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/zh-Hans/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*节假日 is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/zh-Hans/privacy-policy.md
+++ b/docs/zh-Hans/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**节假日 is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in 节假日 Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **节假日 does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use 节假日 Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+节假日 does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**节假日 is a personal project. All inquiries are read and appreciated.**  

--- a/docs/zh-Hans/support.md
+++ b/docs/zh-Hans/support.md
@@ -1,0 +1,54 @@
+# Support for 节假日  
+  
+Thank you for using 节假日. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20节假日%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with 节假日 Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, 节假日 Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does 节假日 Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+节假日 allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. 节假日 does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does 节假日 Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** 节假日 is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/zh-Hans/terms-and-conditions.md
+++ b/docs/zh-Hans/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **节假日**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+节假日 is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+节假日 offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **节假日 Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to 节假日 Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of 节假日 are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+节假日 does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/zh-Hans/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**节假日 is a personal project. If you reach out, I will personally read your message.**  

--- a/docs/zh-Hant/index.md
+++ b/docs/zh-Hant/index.md
@@ -1,0 +1,54 @@
+[![假期 App](images/banner.png)](https://apps.apple.com/app/id6744455042)  
+  
+# 假期  
+  
+假期: your free time, well spent.  
+  
+The simplest, clearest and most powerful way to check Argentina's holidays.  
+With a modern design and day-to-day features, 假期 helps you plan getaways, vacations or simply enjoy your weekends more.  
+  
+Check in seconds when the next holiday is, explore the full calendar and filter non-working days according to your interests, beliefs or lifestyle.  
+  
+Ideal for students, workers, families and anyone who wants to make the most of their days off.  
+  
+## Main Features (Free)  
+  
+• Countdown to the next holiday  
+• Full calendar: national, tourism, and religious holidays  
+• Filters by type: fixed, movable, tourism-related, or non-working days  
+• Search by name or reason for the holiday  
+• Option to hide past holidays  
+• Weekly agenda to view nearby holidays  
+• Modern, clear interface adaptable to all devices  
+  
+## Advanced Features with 假期 Pro  
+  
+• Add holidays to your personal calendar  
+• Receive notifications before each holiday  
+• Filters by community (Muslim, Jewish, Armenian)  
+• Detailed statistics and interactive graphs  
+• Monthly holiday comparisons  
+• Visualization of long weekends  
+• Advanced search by weekday or month  
+• Detailed monthly and weekly calendar view  
+  
+**假期 Pro** includes a free trial. Cancel at least 24 hours before it ends if you don't want to be charged.  
+  
+## Privacy Policy and Terms  
+  
+• [Privacy Policy](https://lucasditomase.github.io/feriados/zh-Hant/privacy-policy)  
+• [Terms and Conditions](https://lucasditomase.github.io/feriados/zh-Hant/terms-and-conditions)  
+  
+## Support  
+  
+If you have questions, suggestions, or want to join the community, feel free to start a [discussion](https://github.com/lucasditomase/feriados/discussions).  
+  
+---  
+  
+*假期 is a personal project. Thank you for supporting independent development.*  
+  
+<p align="left">  
+  <a href="https://apps.apple.com/app/id6744455042">  
+    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+  </a>  
+</p>  

--- a/docs/zh-Hant/privacy-policy.md
+++ b/docs/zh-Hant/privacy-policy.md
@@ -1,0 +1,42 @@
+# Privacy Policy  
+  
+**Last updated: May 2025**  
+  
+**假期 is an app that respects your privacy:** *it does not collect, store, or share any personal user information.*  
+  
+## Data Collection  
+  
+The app does not request unnecessary permissions or access sensitive data.  
+All the information displayed (national, tourism-related, and religious holidays) is public and stored locally on the user's device.  
+  
+The additional features in 假期 Pro, such as holiday statistics and comparisons, are generated and processed locally on your device. No information is sent to or stored on external servers.  
+  
+## In-App Purchases and Free Trial  
+  
+The app offers subscriptions via the App Store. All payment processing, free trials, and subscription management are handled exclusively by Apple. **假期 does not access any personal, financial, or billing information at any time.**  
+  
+If a trial period is available, you may use 假期 Pro at no cost during that time. You will be charged automatically at the end of the trial period, **unless you cancel the subscription at least 24 hours in advance** through your App Store account.  
+  
+## Optional Permissions  
+  
+**Notifications:**  
+Used only if you enable holiday reminders. These are local notifications generated on your device, with no communication to external servers. You can disable them anytime in your device settings.  
+  
+**Calendar:**  
+If you choose to add a holiday to your calendar, a single event is saved with your confirmation. The app **cannot view, read, or modify other existing events.**  
+  
+## Third Parties  
+  
+假期 does not use any third-party services for analytics, advertising, or data storage.  
+  
+## Email Contact  
+  
+If you choose to contact me via email, you will be sharing your email address and the name configured on your account (which may include your last name or other identifying information).  
+  
+This information is used solely to respond to your inquiry. **It is never shared with third parties or sold under any circumstances.**  
+  
+## Contact  
+  
+If you have questions about this policy, feel free to reach out through the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**假期 is a personal project. All inquiries are read and appreciated.**  

--- a/docs/zh-Hant/support.md
+++ b/docs/zh-Hant/support.md
@@ -1,0 +1,54 @@
+# Support for 假期  
+  
+Thank you for using 假期. If you find bugs, have questions, or want to suggest improvements, feel free to contact me or participate in this repository.  
+This is a personal project, so any feedback or contribution is highly appreciated.  
+  
+## Report a Problem  
+  
+You can open an issue in this repository describing the problem and the steps to reproduce it. If possible, please include a screenshot.  
+  
+[Create an issue](https://github.com/lucasditomase/feriados/issues/new?title=Problem%20with%20假期%20App&body=Describe%20the%20issue%20you%E2%80%99re%20experiencing%20below%3A%0A%0A-%20Device%3A%20%0A-%20iOS%20version%3A%20%0A-%20App%20version%3A%20%0A-%20Steps%20to%20reproduce%3A%0A%0A(Optional)%20Attach%20a%20screenshot%20or%20recording%20if%20you%20can.)  
+  
+You can also contact me by email if you prefer not to use GitHub. In the app, under the "More Info" section, there's an option to send an email with all technical details already included (device model, language, OS version, etc.).  
+  
+## Frequently Asked Questions  
+  
+**Can I add holidays to my calendar?**  
+Yes, with 假期 Pro you can add any holiday directly to your personal calendar.  
+  
+**Can I set reminders for holidays?**  
+Yes, 假期 Pro lets you create reminders to get notified before each holiday.  
+  
+**What does the free version include?**  
+It includes the complete calendar of national, tourism-related, and religious holidays, a weekly agenda, and basic filters by type of holiday.  
+  
+**What extra features does 假期 Pro include?**  
+It includes reminders, adding holidays to your calendar, comparative stats, community filters, advanced search, and enhanced calendar views.  
+  
+**Why are there religious holidays?**  
+假期 allows filtering by community (Muslim, Jewish, Armenian) so each user can view relevant dates based on their preferences.  
+  
+**Are holidays always up to date?**  
+The information comes from official public sources and is updated regularly. However, unforeseen changes may occur due to government decisions or human error.  
+  
+**Does the app collect personal data?**  
+No. 假期 does not store or transmit any user data. All activity happens locally on your device.  
+  
+**What happens if I send an email from the app?**  
+You will be sharing your email address and the name configured on your account. This information is used solely to respond to your message. **It is never shared or sold under any circumstances.**  
+  
+**How does 假期 Pro work?**  
+It's an optional subscription that you can activate or cancel from your App Store account. It includes advanced features such as reminders, calendar integration, stats, community filters, advanced search, holiday comparisons, and improved calendar views.  
+  
+**Is there a free trial?**  
+Yes. Both the monthly and annual plans include a free trial. **Important:** remember to cancel *at least 24 hours before the trial ends* if you don’t want to be charged.  
+  
+**Can I share my subscription with my family?**  
+Yes, through Apple Family Sharing, at no additional cost, provided it is properly configured in your App Store account.  
+  
+## Contact  
+  
+If you'd like to get in touch directly or leave a public comment, you can join the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**Your message won’t be lost.** 假期 is a personal project, so I personally read all messages and suggestions.  
+Also, your email address is used only to respond to your inquiry.  

--- a/docs/zh-Hant/terms-and-conditions.md
+++ b/docs/zh-Hant/terms-and-conditions.md
@@ -1,0 +1,88 @@
+# Terms and Conditions of Use  
+  
+**Last updated: May 2025**  
+  
+*By downloading or using the app, you agree to these terms.*  
+  
+These terms govern the use of **假期**, an iOS application developed by **Lucas Di Tomase**, designed to display official holidays in Argentina. You are granted a **limited, non-exclusive, non-transferable, and revocable license** to use the app for personal purposes.  
+  
+## Use of the App  
+  
+假期 is intended for **personal, non-commercial use** only. It may not be used for profit, resale, or as part of another product or service.  
+  
+## Content  
+  
+The information displayed in the app comes from public sources and may be subject to change. While it is regularly updated, **the accuracy, completeness, or timeliness of the information cannot be guaranteed**.  
+  
+## Features and Subscriptions  
+  
+假期 offers basic features for free, including:  
+  
+• Display of national, tourism-related, and religious holidays  
+• Filtering by type of holiday  
+• Weekly agenda of upcoming holidays  
+• Search by name or reason  
+  
+Advanced features are available through a subscription called **假期 Pro**, which includes:  
+  
+• Community-specific filters (Muslim, Jewish, Armenian)  
+• Add holidays to your personal calendar  
+• Set automatic reminders  
+• Visual statistics and comparisons  
+• Long weekend visualization  
+• Advanced search by weekday or month  
+• Monthly and weekly calendar views  
+  
+## Subscriptions and Free Trial  
+  
+• Subscriptions to 假期 Pro **renew automatically** unless canceled at least **24 hours before** the end of the current period  
+• Payment is charged to the Apple ID account used for the purchase  
+• If a **free trial period** is offered, the subscription will begin automatically at the end of the trial unless canceled at least 24 hours in advance  
+• Subscription management and cancellation must be done through your App Store account settings  
+• **Prices may vary depending on region, purchase date, and other conditions set by Apple or by me as the developer.** Prices may be updated in the future, in which case you will be notified prior to automatic renewal so you can decide whether to continue  
+  
+## Family Sharing  
+  
+If you are part of an iCloud Family Sharing group, you may be able to share your subscription with other members, provided this option is enabled and configured in your App Store account. This feature depends on your operating system and individual account settings.  
+  
+## Updates  
+  
+The app may receive periodic updates with performance improvements, bug fixes, or new features without prior notice.  
+  
+## Feedback and Suggestions  
+  
+Any suggestions, comments, or ideas you submit may be used to improve the app, with no obligation for compensation or attribution.  
+  
+## Intellectual Property  
+  
+All content, interfaces, graphics, source code, and features of 假期 are the exclusive property of the developer unless otherwise indicated. No intellectual property rights are granted to the user through use of the app.  
+  
+## Technical Restrictions  
+  
+You are prohibited from:  
+  
+• Selling, distributing, hosting, or commercially exploiting the app without authorization  
+• Copying or using the app for any purpose other than personal and non-commercial use  
+• Modifying, decompiling, reverse engineering, or attempting to access the source code  
+• Using automation, scripts, or other unauthorized methods to interact with the app  
+• Spamming technical support with promotional, abusive, or meaningless messages  
+• Sending messages with missing or altered information intentionally  
+• Emailing technical support and then ignoring replies from the developer  
+• Using the app on a device that has been modified in a way that affects the normal functioning of the app (e.g. jailbroken devices, unauthorized environments, use of third-party app stores)  
+• Using tools that alter the in-app purchase system or any other feature  
+  
+**This list is not exhaustive.** Other cases may also justify restrictions if they compromise the app’s security, integrity, or intended purpose. **I reserve the right to block access to the app, in whole or in part, if improper use or abusive behavior is detected.**  
+  
+## Disclaimer  
+  
+The app is used at your own risk. **Neither the developer (Lucas Di Tomase) nor the app guarantee continuous availability or absolute accuracy of the content and shall not be held responsible for decisions made based on the information provided.**  
+  
+## Privacy  
+  
+假期 does not collect personal data or use third-party services for analytics or advertising. For more details, please refer to the [Privacy Policy](https://lucasditomase.github.io/feriados/zh-Hant/privacy-policy).  
+  
+## Contact  
+  
+For questions, support, or suggestions, feel free to visit the [Discussions](https://github.com/lucasditomase/feriados/discussions) section.  
+  
+**假期 is a personal project. If you reach out, I will personally read your message.**  


### PR DESCRIPTION
## Summary
- remove images from newly added docs
- drop English (UK), Spanish (Latin America) and both Portuguese variants
- keep text docs for languages like Arabic, Russian and Chinese

## Testing
- `grep -n "privacy-policy" docs/zh-Hans/index.md`

------
https://chatgpt.com/codex/tasks/task_e_68619c656464832a8cb65db8b13b3161