### PR TITLE
Remove App Store alt attributes

### DIFF
--- a/docs/ar/index.md
+++ b/docs/ar/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/de/index.md
+++ b/docs/de/index.md
@@ -49,6 +49,6 @@ Wenn du Fragen oder Vorschläge hast oder der Community beitreten möchtest, kan
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Im App Store laden" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -49,6 +49,6 @@ If you have questions, suggestions, or want to join the community, feel free to 
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/fr/index.md
+++ b/docs/fr/index.md
@@ -49,6 +49,6 @@ Si vous avez des questions, des suggestions ou souhaitez rejoindre la communaut�
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Télécharger sur l'App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/hi/index.md
+++ b/docs/hi/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/id/index.md
+++ b/docs/id/index.md
@@ -49,6 +49,6 @@ Jika kamu memiliki pertanyaan, saran, atau ingin bergabung dengan komunitas, sil
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Unduh di App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,6 @@ Si tenés dudas, sugerencias o querés participar de la comunidad, podés abrir 
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="es/images/download-badge.svg" alt="Descargar en App Store" height="60">  
+    <img src="es/images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/it/index.md
+++ b/docs/it/index.md
@@ -49,6 +49,6 @@ Se hai domande, suggerimenti o vuoi partecipare alla community, sentiti libero d
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Scarica sull'App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="App Store でダウンロード" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/ko/index.md
+++ b/docs/ko/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/nl/index.md
+++ b/docs/nl/index.md
@@ -49,6 +49,6 @@ Heb je vragen, suggesties of wil je deelnemen aan de community? Start gerust een
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/pl/index.md
+++ b/docs/pl/index.md
@@ -53,6 +53,6 @@ Jeśli masz pytania, sugestie lub chcesz dołączyć do społeczności, rozpoczn
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Pobierz z App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/pt/index.md
+++ b/docs/pt/index.md
@@ -49,6 +49,6 @@ Se você tiver dúvidas, sugestões ou quiser participar da comunidade, fique à
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Baixar na App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/ru/index.md
+++ b/docs/ru/index.md
@@ -48,6 +48,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/th/index.md
+++ b/docs/th/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="ดาวน์โหลดบน App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/tr/index.md
+++ b/docs/tr/index.md
@@ -57,6 +57,6 @@ teşekkürler.*
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="App Store'dan İndir" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/uk/index.md
+++ b/docs/uk/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Завантажити в App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/vi/index.md
+++ b/docs/vi/index.md
@@ -50,6 +50,6 @@ Nếu bạn có câu hỏi, đề xuất hoặc muốn tham gia cộng đồng, 
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Tải về trên App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/zh-hans/index.md
+++ b/docs/zh-hans/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  

--- a/docs/zh-hant/index.md
+++ b/docs/zh-hant/index.md
@@ -49,6 +49,6 @@
 
 <p align="left">  
   <a href="https://apps.apple.com/app/id6744455042">  
-    <img src="images/download-badge.svg" alt="Download on the App Store" height="60">  
+    <img src="images/download-badge.svg" height="60">  
   </a>  
 </p>  


### PR DESCRIPTION
## Summary
- drop the `alt` attribute from the App Store badge on every index page in `docs`

## Testing
- `bash trim-and-add-spaces.sh`

------
https://chatgpt.com/codex/tasks/task_e_68740f0b8828832a91e98397a6be7309